### PR TITLE
2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `laravel-package-toolkit` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [2.0.2] - 2026-06-30
+
+### Fixed
+
+- **About command data not merging** — Custom about data returned from `aboutData()`
+  on a service provider was never included in the `php artisan about` output; only the
+  package `Version` was displayed. The provider's `aboutData()` is now passed through to
+  the packager and merged with the version data as documented.

--- a/src/Concerns/HasAboutCommand.php
+++ b/src/Concerns/HasAboutCommand.php
@@ -26,6 +26,11 @@ trait HasAboutCommand
     private bool $isAboutable = false;
 
     /**
+     * @var array<string, string|Closure> Additional data for the AboutCommand
+     */
+    private array $aboutData = [];
+
+    /**
      * Retrieves a specific value from the composer.json file by key name.
      *
      * @param  string  $keyName  The key to retrieve from composer.json.
@@ -76,11 +81,23 @@ trait HasAboutCommand
     /**
      * Returns additional data for AboutCommand.
      *
-     * @return array<string|Closure>
+     * @return array<string, string|Closure>
      */
     public function aboutData(): array
     {
-        return [];
+        return $this->aboutData;
+    }
+
+    /**
+     * Sets the additional data to be displayed in the AboutCommand.
+     *
+     * @param  array<string, string|Closure>  $data  The additional about data.
+     */
+    public function setAboutData(array $data): static
+    {
+        $this->aboutData = $data;
+
+        return $this;
     }
 
     /**

--- a/src/Contracts/ProvidesPackageServices.php
+++ b/src/Contracts/ProvidesPackageServices.php
@@ -65,4 +65,14 @@ interface ProvidesPackageServices
      * @return array<string|object> List of command classes.
      */
     public function packageCommands(): array;
+
+    /**
+     * Get the additional data for the AboutCommand.
+     *
+     * Override this method to add custom key-value pairs to the package's
+     * section in the `php artisan about` command output.
+     *
+     * @return array<string, string|\Closure> Custom about data.
+     */
+    public function aboutData(): array;
 }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -214,6 +214,19 @@ abstract class PackageServiceProvider extends ServiceProvider implements Provide
     }
 
     /**
+     * Get the additional data for the AboutCommand.
+     *
+     * Override this method to add custom key-value pairs to your package's
+     * section in the `php artisan about` command output.
+     *
+     * @return array<string, string|\Closure> Custom about data
+     */
+    public function aboutData(): array
+    {
+        return [];
+    }
+
+    /**
      * Validate the packager instance.
      *
      * @throws PackageConfigurationException When packager is invalid

--- a/src/Support/Concerns/BootsPackageResources.php
+++ b/src/Support/Concerns/BootsPackageResources.php
@@ -12,6 +12,13 @@ trait BootsPackageResources
     use BladeComponentLoader;
 
     /**
+     * Get the additional data for the AboutCommand.
+     *
+     * @return array<string, string|\Closure>
+     */
+    abstract public function aboutData(): array;
+
+    /**
      * Boot the package resources.
      *
      * This method boots the package by calling other methods that
@@ -51,6 +58,7 @@ trait BootsPackageResources
             return $this;
         }
 
+        $this->packager->setAboutData($this->aboutData());
         $this->packager->bootAboutCommand();
 
         return $this;

--- a/tests/PackageProviderTests/PackageServiceProviderTestCase.php
+++ b/tests/PackageProviderTests/PackageServiceProviderTestCase.php
@@ -2,6 +2,7 @@
 
 namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
 
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -18,6 +19,7 @@ abstract class PackageServiceProviderTestCase extends TestCase
     {
         $this->resetServiceProviderState();
         TestServiceProvider::$providerUsing = fn (Packager $packager) => $this->configure($packager);
+        TestServiceProvider::$aboutDataUsing = null;
         parent::setUp();
 
         $this->clear();
@@ -80,6 +82,7 @@ abstract class PackageServiceProviderTestCase extends TestCase
         $this->resetStaticProperty(ServiceProvider::class, 'publishGroups', []);
         $this->resetStaticProperty(ServiceProvider::class, 'publishableMigrationPaths', []);
         $this->resetStaticProperty(PackageServiceProvider::class, 'isPackageAboutRegistered', false);
+        AboutCommand::flushState();
     }
 
     /**

--- a/tests/TestPackageData/src/TestServiceProvider.php
+++ b/tests/TestPackageData/src/TestServiceProvider.php
@@ -10,8 +10,15 @@ class TestServiceProvider extends PackageServiceProvider
 {
     public static ?Closure $providerUsing = null;
 
+    public static ?Closure $aboutDataUsing = null;
+
     public function configure(Packager $packager): void
     {
         (self::$providerUsing ?? fn (Packager $packager) => null)($packager);
+    }
+
+    public function aboutData(): array
+    {
+        return (self::$aboutDataUsing ?? fn () => [])();
     }
 }


### PR DESCRIPTION
### Fixed

- **About command data not merging** — Custom about data returned from `aboutData()`
  on a service provider was never included in the `php artisan about` output; only the
  package `Version` was displayed. The provider's `aboutData()` is now passed through to
  the packager and merged with the version data as documented.
