### PR TITLE
2.2.0 — events, optimize & configurable publish tag separators

### DIFF
--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -1,0 +1,61 @@
+# Internal architecture (contributor reference for AI agents)
+
+Audience: an AI agent working **on this repository** — changing or extending the toolkit itself. For using the toolkit from another project, see [consuming-the-toolkit.md](./consuming-the-toolkit.md).
+
+## Two collaborators + single-responsibility traits
+
+The library is built from two classes and a large set of traits, split by which class they belong to.
+
+**`PackageServiceProvider` (abstract, `src/PackageServiceProvider.php`)** — the class consumers extend. Drives the Laravel lifecycle:
+- `register()`: creates a `Packager` (`bootPackager()`), sets its base path via reflection on the subclass's file location (`getPackageBaseDir()`), calls the consumer's `configure()`, runs conditional callbacks (`executeConditionalCallbacks()`), validates, then `registerConfig()` + `registerInstallCommand()` + `performAutoInstall()`, firing the registering/registered hooks around it.
+- `boot()`: `registerPublishing()` → `registerPackageCommands()` → `registerAboutCommand()` → `bootPackageResources()`, wrapped in booting/booted hooks.
+- Mixes in the **provider-side** `Support\Concerns\*` traits: `BootsPackageResources` (loads routes/views/migrations/etc. into the running app), `PublishesPackageResources` (registers `publishes()` groups + tags), `HasEnvironmentChecks`, `HasNamespaceResolver`, `HasPublishingTag`.
+
+**`Packager` (`src/Packager.php`)** — the fluent configuration object passed to `configure()`. A bag of state assembled from the **consumer-side** `Concerns\*` traits (`HasConfig`, `HasRoutes`, `HasMigrations`, `HasViews`, `HasCommands`, `HasMiddleware`, `HasEvents`, `HasOptimize`, `HasPublishTagSeparator`, `HasTranslate`, `HasAssets`, `HasProviders`, `HasConditionalLoading`, `HasViewComponents`/`Namespaces`/`Composers`, `HasViewSharedData`, `HasAboutCommand`, `HasInstallation`, plus `Support\Concerns\HasLifecycleHooks`). Each feature trait follows the same shape: a `hasX()` builder that records intent, an `isX()`/`isSetX()` predicate, and a getter. `FilesResolver` underpins them all — cross-platform (Windows-aware) path normalization, discovery, and validation live there.
+
+## The trait split is the key mental model
+
+- `src/Concerns/` → traits mixed into **`Packager`** — *declare* what the package has.
+- `src/Support/Concerns/` → traits mixed into **`PackageServiceProvider`** — *act on* that declaration at register/boot time.
+
+A single feature therefore spans both sides. Example — **middleware**:
+- `Concerns/HasMiddleware.php` stores aliases/groups/globals and exposes `isSetMiddleware*()` + getters.
+- `Support/Concerns/BootsPackageResources::bootMiddleware()` reads them and calls the router/kernel.
+
+## Adding or changing a resource type
+
+Expect to touch several coordinated places:
+1. **Declaration** — a `Concerns/HasX.php` trait with `hasX()` builder, an `isX()` predicate, a getter; add the `use` to `Packager`.
+2. **Boot** — a `bootX()` method in `Support/Concerns/BootsPackageResources.php`, added to the ordered chain in `bootPackageResources()`.
+3. **Publishing** — a `publishX()` method in `Support/Concerns/PublishesPackageResources.php` (tags via `HasPublishingTag::publishTagFormat()`, format `"{shortName}::{group}"`).
+4. **Install command** — a matching `publishX()` in `Commands/Concerns/PublishableResources.php` so the install command can select it.
+
+Steps 3–4 apply only to resources that ship files to publish. Register-only resources (e.g. `HasEvents`, `HasOptimize`) need just steps 1–2: a declaration trait plus a `bootX()` in the chain. `bootOptimizes()` forwards to the provider's own `optimizes()` (a `ServiceProvider` method); if a new register-only feature adds static state to `ServiceProvider`, reset it in `PackageServiceProviderTestCase::resetServiceProviderState()` (as done for `optimizeCommands`/`optimizeClearCommands`).
+
+## Install command
+
+`HasInstallation` (Packager side) marks the package installable and builds an `InstallCommand` (`src/Commands/InstallCommand.php`); the provider registers it (`registerInstallCommand()`), or runs it silently when `installOnRun()` is set (`performSilentInstallation()` with `ArrayInput --no-interaction` + `NullOutput`). `Commands/Concerns/PublishableResources.php` holds the publishable-tag selection logic shared with the command. Install-command names are prefixed with the package short name (`{shortName}:install`).
+
+## Lifecycle hooks
+
+`LifecycleHook` enum (`Registering`, `Registered`, `Booting`, `Booted`, `src/Support/Enums/`). Consumers register callbacks on the Packager via `HasLifecycleHooks` (`registeringPackage()` etc.); the provider fires them at the matching lifecycle point through `executeLifecycleHook()`, which no-ops when a hook wasn't defined. Note the name collision: `Packager` methods *set* the callbacks; `PackageServiceProvider` methods of the same name *fire* them.
+
+## Contracts and exceptions
+
+- **Contracts** (`src/Contracts/`) — `Packable`, `ProvidesPackageServices` (extends `Packable`), `HasAbout` define the public surface consumers implement/rely on.
+- **Exceptions** — `src/Exceptions/` (`MissingNameException`, `InvalidReturnTypeException`, `InvalidLanguageDirectoryException`) plus top-level `PackageConfigurationException`; thrown from validation paths in `register()`/`registerConfig()`.
+
+## Tests
+
+- `tests/PackageProviderTests/` — integration-style, one file per feature, extending `PackageServiceProviderTestCase`. Each test implements `configure(Packager $packager)`; that closure is injected into the shared `TestServiceProvider` (`tests/TestPackageData/src/`) at runtime via a static `Closure` — this is how one test provider is reconfigured per test.
+- `tests/Unit/` — direct unit tests of individual traits/classes.
+- `tests/TestPackageData/` — fixture config, routes, migrations, lang, stubs (the "package under test").
+- `PackageServiceProviderTestCase::setUp()` resets static provider state (`ServiceProvider::$publishes`/`$publishGroups`/`$publishableMigrationPaths`, the once-only `$isPackageAboutRegistered` flag, `AboutCommand::flushState()`) and cleans published config/migrations between tests — important because provider registration mutates static Laravel state. Follow this pattern when a new feature adds static state.
+- Runs against Orchestra Testbench; no separate DB/app setup needed.
+
+## Conventions
+
+- Every `hasX()` builder returns `static` for chaining and validates eagerly (e.g. `name()` rejects empty, `hasShortName()` enforces kebab-case).
+- PHPStan runs at **level 5 over `src` only** — keep new code passing; tests are not analyzed.
+- Formatting is enforced by Pint (`pint.json`); run `composer pint` before finishing.
+- Do not attribute commits to any AI tool/vendor in commit messages.

--- a/.ai/consuming-the-toolkit.md
+++ b/.ai/consuming-the-toolkit.md
@@ -1,0 +1,221 @@
+# Using laravel-package-toolkit (consumer reference for AI agents)
+
+Audience: an AI agent working **in another project** that wants to build a Laravel package with `nyoncode/laravel-package-toolkit`. This is the complete public API, extracted from source. Everything is a fluent builder — every `Packager` method returns `static`, so chain freely.
+
+## Mental model
+
+1. Create a service provider that **extends `PackageServiceProvider`** and implement one method: `configure(Packager $packager)`.
+2. Inside `configure()`, declare what your package *has* by calling `hasX()` methods on `$packager`. Order does not matter; declaration is decoupled from the boot pipeline.
+3. The toolkit resolves paths **relative to the directory of your service provider file** (via reflection). If the provider lives in `src/Providers/`, the base path is auto-corrected up to `src/`'s parent. This is why defaults look like `../config`, `../routes`, `../resources/views`.
+4. `name()` is the only required call. Without it registration throws `MissingNameException`.
+
+Minimal package:
+
+```php
+use NyonCode\LaravelPackageToolkit\PackageServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+class MyPackageServiceProvider extends PackageServiceProvider
+{
+    public function configure(Packager $packager): void
+    {
+        $packager
+            ->name('My Package')
+            ->hasConfig()
+            ->hasRoutes()
+            ->hasMigrations()
+            ->hasTranslations()
+            ->hasViews();
+    }
+}
+```
+
+Register it in `composer.json` (`extra.laravel.providers`) as usual for a Laravel package.
+
+## Naming
+
+| Method | Signature | Notes |
+|---|---|---|
+| `name` | `name(string $name): static` | **Required.** Throws `InvalidArgumentException` if empty. |
+| `hasShortName` | `hasShortName(string $shortName): static` | Override the auto-generated slug. Must be kebab-case (`^[a-z0-9-]+$`) or throws. |
+| `shortName` | `shortName(): string` | Read the slug. Defaults to `Str::kebab($name)`. Used as the view namespace, translation namespace, and publish-tag prefix. |
+
+## Config
+
+- `hasConfig(string|array|null $configFiles = null, string $directory = '../config'): static`
+- `null` → auto-discover **all** files in `../config`. Pass a filename or array of filenames to select specific ones.
+- Each config file **must `return` an array** or registration throws `InvalidReturnTypeException`.
+- Config is merged (`mergeConfigFrom`) under the file's basename as the key.
+
+## Routes
+
+- `hasRoutes(array|string|null $routeFiles = null, string $directory = '../routes'): static`
+- `null` → load all route files in `../routes`; or pass specific filenames (`['api.php', 'web.php']`).
+- Loaded via `loadRoutesFrom` at boot.
+
+## Migrations
+
+- `hasMigrations(?array $migrationFiles = null, string $directory = '../database/migrations'): static`
+- Supports both timestamped (`2025_01_01_000000_create_x.php`) and **timeless** (`create_x.php`) migrations. Timeless ones get a sequential timestamp prefix automatically **when published** (`getMigrationPublishMapping()`).
+- `canLoadMigrations(bool $value = true): static` — when true, migrations are *loaded from the package* at boot (run without publishing). Default is off; call this to enable run-in-place.
+
+## Translations
+
+- `hasTranslations(string $translationPath = 'lang'): static` — loads both PHP and JSON translations. PHP translations are namespaced under `shortName()` (e.g. `__('my-package::messages.key')`); JSON translations are global.
+
+## Views
+
+- `hasViews(?string $viewsPath = null, string $directory = '../resources/views', ?string $namespace = null): static`
+- Views are registered under the `shortName()` namespace (e.g. `view('my-package::index')`) unless you pass an explicit `$namespace`.
+- `$viewsPath` accepts absolute or relative paths; throws `DirectoryNotFoundException` if missing.
+
+### View components
+
+- `hasComponent(string $prefix, string $componentClass, string $alias = ''): static` — one component.
+- `hasComponents(string $prefix, array|string $components): static` — many. String keys in the array become aliases: `['modal' => Modal::class]`.
+
+### View component namespaces
+
+- `hasComponentNamespace(string $prefix, string $namespace): static`
+- `hasComponentNamespaces(array $namespaces): static` — `['prefix' => 'App\\View\\Components']`.
+
+### View composers
+
+- `hasViewComposer(string|array $views, string|Closure $composer): static` — bind data when a view renders. `$composer` is a class name or a closure.
+
+### Shared view data
+
+- `hasSharedDataForAllViews(array $viewSharedData): static` — `View::share()` for every key/value.
+
+## Middleware
+
+- `hasMiddlewareAliases(array $aliases): static` — `['role' => EnsureRole::class]`.
+- `hasMiddlewareGroups(array $groups): static` — `['api' => [Throttle::class, ...]]`, pushed to the group.
+- `hasMiddlewareGlobals(array $middlewares): static` — pushed to the HTTP kernel globally.
+
+## Events
+
+Register event listeners and subscribers; applied at boot via the `Event` facade.
+
+- `hasEvents(array $events): static` — a map of `event => listener(s)`. Each value is a class-string, a closure, or an array of them: `[OrderPlaced::class => [SendMail::class, LogOrder::class]]`.
+- `hasEvent(string $event, string|Closure|array $listeners): static` — one event.
+- `hasSubscribers(array $subscribers): static` / `hasSubscriber(string $subscriber): static` — event subscriber classes (registered via `Event::subscribe`).
+
+```php
+$packager
+    ->hasEvent(OrderPlaced::class, SendOrderConfirmation::class)
+    ->hasSubscriber(OrderEventSubscriber::class);
+```
+
+## Optimize
+
+Register artisan commands that run with `php artisan optimize` (cache warmup) and `php artisan optimize:clear` — the toolkit forwards to Laravel's `ServiceProvider::optimizes()`.
+
+- `hasOptimizeCommands(?string $optimize = null, ?string $clear = null, ?string $key = null): static`
+- At least one of `$optimize`/`$clear` must be set (otherwise it's a no-op). `$key` defaults to the package short name at boot.
+- Registering **multiple** entries: give each a distinct `$key` — entries sharing a key overwrite one another (Laravel keys optimize commands by provider).
+
+```php
+$packager->hasOptimizeCommands(
+    optimize: 'my-package:cache',
+    clear: 'my-package:clear',
+);
+```
+
+## Commands
+
+- `hasCommands(string|array|null $commandsClass = null, string $directory = 'Commands'): static` — register command classes, or auto-discover from a directory when `null`.
+- `hasCommand(string $commandClass): static` — a single command.
+- You can also override `public function packageCommands(): array` on the service provider to return commands.
+
+## Assets
+
+- `hasAssets(string $directory = 'dist'): static` — mark a directory of built assets as publishable.
+
+## Providers (extra service providers)
+
+- `hasProvider(string $provider): static`
+- `hasProviders(array $providers): static`
+- Used with the install command to copy/register additional providers into the consuming app.
+
+## About command
+
+Adds a section to `php artisan about`.
+
+- `hasAbout(bool $value = true): static`
+- `hasVersion(string $version): static` — otherwise the installed composer version is auto-detected.
+- Override `public function aboutData(): array` on the service provider to add custom `key => string|Closure` rows.
+
+## Conditional loading
+
+Guards run **immediately after** `configure()`. The callback receives the `Packager`.
+
+- `when(bool $condition, Closure $callback)` / `unless(bool $condition, Closure $callback)`
+- `whenMultiple(array $conditions)` — array of `[bool, Closure]` pairs.
+- `whenEnvironment(string|array $environments, Closure $callback)`, `whenProduction(Closure)`, `whenLocal(Closure)`, `whenConsole(Closure)`
+- `whenClassExists(string $class, Closure)`, `whenFunctionExists(string $function, Closure)`, `whenExtensionLoaded(string $extension, Closure)`
+
+```php
+$packager->whenLocal(fn (Packager $p) => $p->hasRoutes('dev.php'));
+```
+
+## Lifecycle hooks
+
+Register callbacks that fire at provider lifecycle points. Each receives the `Packager`.
+
+- `registeringPackage(Closure)` — before `register()` work
+- `registeredPackage(Closure)` — after register
+- `bootingPackage(Closure)` — before boot
+- `bootedPackage(Closure)` — after boot
+
+(These four `Packager` methods set callbacks. The service provider has same-named methods that *fire* them — don't confuse the two; as a consumer you call them on `$packager`.)
+
+## Install command
+
+Enable an interactive `php artisan <short-name>:install` command.
+
+Toggles on `Packager`:
+- `hasInstallCommand(?Closure $callback = null)` — enable; the closure configures the `InstallCommand` (see publish methods below).
+- Presets: `hasQuickInstall()` (config+migrations+assets), `hasFullInstall()` (everything), `hasMinimalInstall()` (config only), `hasDevInstall()` (config+migrations+views+assets, routes only in local).
+- `installCommandName(string $name)` — rename (prefixed with short name → `short-name:name`).
+- `installCommandHidden(bool $hidden = true)` — hide from `artisan list`.
+- `installOnRun(bool = true)`, `installOnRunInEnvironment(string|array)`, `installOnRunInLocal()`, `installOnRunInProduction()` — run install silently on boot.
+- `withoutInstallCommand()` — disable.
+
+Inside the install-command callback (`InstallCommand` methods), select what to publish:
+- Per-resource: `publishConfig()`, `publishMigrations()`, `publishRoutes()`, `publishViews()`, `publishAssets()`, `publishTranslations()`, `publishProviders()`, `publishComponents()`, `publishComponentNamespaces()` (plus verbose aliases like `publishConfigFiles()`, `publishLanguageFiles()`, `publishServiceProviders()`…).
+- Bulk: `publishEverything()` / `publishAll()`, `publishEssentials()`.
+- Conditional: `publishIf(bool, ...$tags)`, `publishUnless(bool, ...$tags)`, `publishForEnvironment(string|array, ...$tags)`, `publishForProduction(...$tags)`, `publishForLocal(...$tags)`, `publishCustom(...$tags)`.
+- Hooks/UX: `beforeInstallation(Closure)`, `afterInstallation(Closure)`, `silent()`, `copyAndRegisterServiceProviderInApp(?string $providerClass = null)`, `askToStarRepoOnGitHub(?string $repoUrl = null)`.
+
+```php
+$packager->hasInstallCommand(function (InstallCommand $command) {
+    $command->publishConfig()
+        ->publishMigrations()
+        ->publishForLocal('routes')
+        ->askToStarRepoOnGitHub('https://github.com/you/pkg');
+});
+```
+
+## Publishing tags
+
+Publish groups are tagged `"{shortName}{separator}{group}"`. The default separator is `::`, e.g. `my-package::config`. Consumers of *your* package publish with:
+
+```bash
+php artisan vendor:publish --tag="my-package::config"
+```
+
+To use the classic flat format (`my-package-config`), set the separator in `configure()`:
+
+- `hasPublishTagSeparator(string|array $separator): static` — e.g. `->hasPublishTagSeparator('-')`.
+- Pass an **array** to register every group under multiple tag forms at once: `->hasPublishTagSeparator(['::', '-'])` makes both `my-package::config` and `my-package-config` publish the same resource. The first separator is primary (used by the install command).
+
+It applies to every publish tag and to the install command consistently. Groups: `config`, `migrations`, `routes`, `translations`, `assets`, `views`, `providers`, `view-components`, `view-component-namespaces`.
+
+## Common gotchas
+
+- Paths are relative to the **provider file's directory**; the default prefixes (`../config`, etc.) assume the provider is one level deep (e.g. `src/`). Adjust the `$directory` argument if your layout differs.
+- Forgetting `name()` → `MissingNameException` at registration.
+- A config file that doesn't `return []` → `InvalidReturnTypeException`.
+- Migrations are **not** loaded at runtime unless you call `canLoadMigrations()`; otherwise they are publish-only.
+- `configure()` must not return a value (`void`); it mutates `$packager`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+# GitHub Copilot instructions
+
+See [AGENTS.md](../AGENTS.md) — the single, tool-agnostic source of guidance for this repository. All project instructions live there, including:
+
+- **Using this toolkit** to build a package → [.ai/consuming-the-toolkit.md](../.ai/consuming-the-toolkit.md)
+- **Working on the toolkit itself** → [.ai/architecture.md](../.ai/architecture.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, and any tool that reads `AGENTS.md`) working with this repository. Single source of truth; tool-specific files (e.g. `CLAUDE.md`) just point here.
+
+## What this is
+
+`nyoncode/laravel-package-toolkit` is a library (not an app) that Laravel package authors extend to wire up their own package's resources — config, routes, migrations, translations, views, view components, middleware, commands, assets — through a fluent API instead of boilerplate. Consumers subclass `PackageServiceProvider` and describe their package inside `configure(Packager $packager)`.
+
+Requires PHP ^8.2 and Laravel 12.x (>= 12.61.1) or 13.x (>= 13.12.0). Laravel 10/11 support was dropped in v2.1 (see README for the CVE rationale).
+
+## Which doc do you need?
+
+- **Using the toolkit** to build a package in another project → [.ai/consuming-the-toolkit.md](./.ai/consuming-the-toolkit.md) — the complete public fluent API, extracted from source, with examples and gotchas.
+- **Working on the toolkit itself** (changing/extending it) → [.ai/architecture.md](./.ai/architecture.md) — internal architecture, the trait split, how to add a resource type, test patterns.
+
+## Commands
+
+Composer scripts wrap the underlying tools — prefer them:
+
+- `composer test` — run the full Pest suite (`vendor/bin/pest`)
+- `composer lint` — run PHPStan (level 5, `src` only)
+- `composer pint` — apply Laravel Pint formatting
+
+Running a subset of tests (Pest filters):
+
+- `vendor/bin/pest tests/PackageProviderTests/PackageConfigTest.php` — a single file
+- `vendor/bin/pest --filter="registers config"` — by description substring
+
+The suite runs against Orchestra Testbench (a bootstrapped Laravel app), so no separate DB/app setup is needed. `composer build` / `composer serve` build and serve the Testbench workbench app.
+
+## Orientation (the one thing to know)
+
+The library has two collaborators, and traits are split by which one they belong to:
+
+- `src/Concerns/` → mixed into **`Packager`** — *declare* what the package has (`hasConfig()`, `hasRoutes()`, …).
+- `src/Support/Concerns/` → mixed into **`PackageServiceProvider`** — *act on* that declaration at register/boot time (`bootRoutes()`, `publishConfig()`, …).
+
+So each feature spans both sides. Full detail — including how to add a new resource type and the test-state reset pattern — is in [.ai/architecture.md](./.ai/architecture.md).
+
+## Conventions
+
+- Every `hasX()` builder returns `static` for chaining and validates eagerly (e.g. `name()` rejects empty, `hasShortName()` enforces kebab-case).
+- PHPStan runs at level 5 over `src` only — keep new code passing; tests are not analyzed.
+- Formatting is enforced by Pint (`pint.json`); run `composer pint` before finishing.
+- Do not attribute commits to any AI tool/vendor in commit messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `laravel-package-toolkit` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.2.0] - 2026-07-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `laravel-package-toolkit` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Event registration** — `hasEvents()`, `hasEvent()`, `hasSubscribers()` and `hasSubscriber()` register event
+  listeners and subscribers, applied at boot via the `Event` facade.
+- **Optimize command registration** — `hasOptimizeCommands()` registers artisan commands that run with
+  `php artisan optimize` and `php artisan optimize:clear`, forwarding to Laravel's `ServiceProvider::optimizes()`.
+- **Configurable publish tag separator** — `hasPublishTagSeparator()` sets the separator used for publish tags.
+  Pass `-` for the classic flat format (`my-package-config`) instead of the default `my-package::config`; applies to
+  `vendor:publish` tags and the install command alike. Pass an array (e.g. `['::', '-']`) to register every group
+  under multiple tag forms at once, with the first separator treated as primary.
+
 ## [2.1.1] - 2026-07-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](./AGENTS.md) — the single, tool-agnostic source of guidance for this repository. All project instructions live there.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ developers to focus on building features rather than boilerplate code.
 - Conditional resource loading based on environment
 - Lifecycle hooks for advanced customization
 - Middleware registration and management
+- Event listener and subscriber registration
+- Optimize command registration (`php artisan optimize` / `optimize:clear`)
 
 ## Support Laravel
 
@@ -38,6 +40,8 @@ developers to focus on building features rather than boilerplate code.
 - [Config](#config)
 - [Routing](#routing)
 - [Middlewares](#middlewares)
+- [Events](#events)
+- [Optimize](#optimize)
 - [Migrations](#migrations)
 - [Translations](#translations)
 - [Commands](#commands)
@@ -373,6 +377,67 @@ $packager->hasMiddlewareGlobals([
 
 This middleware will be added to the middleware stack and is useful for applying middleware to all routes regardless of
 their group.
+
+## Events
+
+Register event listeners and subscribers for your package. Bindings are applied during `boot()` via the `Event` facade.
+
+### Register Event Listeners
+
+Provide a map of event class to listener(s). A value may be a single listener, a closure, or an array of listeners:
+
+```php
+$packager->hasEvents([
+    \Vendor\Package\Events\OrderPlaced::class => [
+        \Vendor\Package\Listeners\SendOrderConfirmation::class,
+        \Vendor\Package\Listeners\LogOrder::class,
+    ],
+    \Vendor\Package\Events\OrderShipped::class => \Vendor\Package\Listeners\NotifyCustomer::class,
+]);
+```
+
+To register a single event, use `hasEvent()`:
+
+```php
+$packager->hasEvent(
+    \Vendor\Package\Events\OrderPlaced::class,
+    \Vendor\Package\Listeners\SendOrderConfirmation::class
+);
+```
+
+### Register Event Subscribers
+
+Subscriber classes (with a `subscribe()` method) are registered via `Event::subscribe()`:
+
+```php
+$packager
+    ->hasSubscriber(\Vendor\Package\Listeners\OrderEventSubscriber::class)
+    ->hasSubscribers([
+        \Vendor\Package\Listeners\UserEventSubscriber::class,
+        \Vendor\Package\Listeners\PaymentEventSubscriber::class,
+    ]);
+```
+
+## Optimize
+
+Register artisan commands that run with `php artisan optimize` (cache warmup) and `php artisan optimize:clear`. The
+toolkit forwards these to Laravel's `ServiceProvider::optimizes()`.
+
+```php
+$packager->hasOptimizeCommands(
+    optimize: 'my-package:cache',
+    clear: 'my-package:clear',
+);
+```
+
+At least one of `optimize` or `clear` must be provided. The cache key defaults to the package short name; when registering
+more than one entry, pass a distinct `key` for each, since Laravel keys optimize commands by provider:
+
+```php
+$packager
+    ->hasOptimizeCommands(optimize: 'my-package:cache-config', clear: 'my-package:clear-config', key: 'my-package-config')
+    ->hasOptimizeCommands(optimize: 'my-package:cache-routes', clear: 'my-package:clear-routes', key: 'my-package-routes');
+```
 
 ## Migrations
 
@@ -901,6 +966,38 @@ php artisan vendor:publish --tag=my-package::assets
 
 # Publish with force (overwrite existing files)
 php artisan vendor:publish --tag=my-package::config --force
+```
+
+### Custom tag separator (classic flat format)
+
+By default tags use the `::` separator (`my-package::config`). If you prefer the classic flat format that many packages
+use (`my-package-config`), set a custom separator with `hasPublishTagSeparator()`:
+
+```php
+$packager
+    ->name('Backup Manager')
+    ->hasPublishTagSeparator('-')   // tags become {short-name}-{resource}
+    ->hasConfig();
+```
+
+The separator applies to **every** publish tag and to the install command consistently:
+
+```bash
+php artisan vendor:publish --tag="backup-manager-config"
+php artisan vendor:publish --tag="backup-manager-migrations"
+```
+
+To register every group under **multiple** tag forms at once — so consumers can publish with either — pass an array.
+The first separator is treated as primary (used by the install command):
+
+```php
+$packager->hasPublishTagSeparator(['::', '-']);
+```
+
+```bash
+# both work and publish the same resource
+php artisan vendor:publish --tag="backup-manager::config"
+php artisan vendor:publish --tag="backup-manager-config"
 ```
 
 ### Migration publishing behavior

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "php": "^8.2",
         "ext-readline": "*",
         "composer/composer": "^2.8",
-        "illuminate/support": "^12.61.1|^13.12.0"
+        "illuminate/support": "^12.61.1|^13.12.0",
+        "laravel/pint": "^1.29"
     },
     "require-dev": {
-        "laravel/pint": "^1.20",
         "mockery/mockery": "^1.5",
         "orchestra/testbench": "^10.0|^11.0",
         "pestphp/pest": "^3.1|^4.0",
@@ -61,7 +61,7 @@
             "@php vendor/bin/testbench serve --ansi"
         ],
         "lint": [
-            "@php vendor/bin/phpstan analyse --verbose --ansi"
+            "@php vendor/bin/phpstan analyse --verbose --ansi --memory-limit=512M"
         ],
         "test": [
             "@php vendor/bin/pest"

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -1,0 +1,185 @@
+# The Platform — end-to-end walkthrough
+
+How the manifest-based platform (see [ROADMAP.md](ROADMAP.md)) works in practice, from
+three perspectives: package author, consuming application, and production. Each element
+is annotated with the track/release that delivers it.
+
+---
+
+## 1. Package author (Alice builds `alice/blog-engine`)
+
+Scaffold *(Track C — Studio CLI)*:
+
+```bash
+nyon new alice/blog-engine
+# ? Which resources will the package ship? › config, routes, views, migrations
+# ? CI matrix? › PHP 8.3–8.5 × Laravel 12–13
+# ✓ Skeleton with Testbench, Pest, Pint, PHPStan, GitHub Actions ready
+```
+
+The provider needs only the minimum — or the classic explicit `hasX()` chain; both are
+first-class and both produce the same manifest *(Track B — 3.0)*:
+
+```php
+class BlogEngineServiceProvider extends PackageServiceProvider
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Blog Engine')
+            ->discover()                        // conventional layout wires itself
+            ->hasConfig(BlogConfig::class);     // typed config on top
+    }
+}
+```
+
+Development loop *(Track C — Studio CLI)*:
+
+```bash
+nyon dev    # playground app (testbench serve), file watching — save a view, see it
+```
+
+Tests with the toolkit testing kit *(Track B — 3.0)*:
+
+```php
+it('publishes what it promises', function () {
+    $this->assertPackagePublishes('blog-engine::config', config_path('blog-engine.php'));
+    $this->assertPackageRegistersCommand('blog:prune');
+    $this->assertPackageManifestCacheable();   // catches closures that would break caching
+});
+```
+
+Release — this is where the platform's key artifact is produced
+*(manifest build: Track B; `nyon release` + protocol: Track C)*:
+
+```bash
+nyon release
+# ✓ CHANGELOG generated
+# ✓ .nyon/manifest.json built
+# ✓ Manifest diff against v1.2.0 included in release notes
+```
+
+```json
+{
+  "$schema": "https://nyoncode.dev/schemas/package-manifest/v1.json",
+  "name": "blog-engine",
+  "provider": "Alice\\BlogEngine\\BlogEngineServiceProvider",
+  "resources": {
+    "config":     [{ "file": "config/blog-engine.php", "key": "blog-engine",
+                     "typed": "Alice\\BlogEngine\\BlogConfig" }],
+    "routes":     [{ "file": "routes/web.php" }],
+    "views":      { "namespace": "blog-engine", "path": "resources/views" },
+    "commands":   [{ "signature": "blog:prune" }],
+    "middleware": { "aliases": { "blog.auth": "…" }, "groups": {}, "global": [] }
+  },
+  "capabilities": ["routes", "commands", "middleware.alias"],
+  "publishes":    ["config", "views", "migrations"]
+}
+```
+
+---
+
+## 2. Consuming application (Bob installs the package)
+
+```bash
+composer require alice/blog-engine
+php artisan package:audit
+```
+
+```
+┌──────────────┬────────┬────────────────┬──────────┬───────────────────┐
+│ Package      │ Routes │ Middleware     │ Commands │ Flags             │
+├──────────────┼────────┼────────────────┼──────────┼───────────────────┤
+│ blog-engine  │ 1      │ 1 alias        │ 1        │ –                 │
+│ acme-metrics │ 0      │ ⚠ 1 GLOBAL     │ 2        │ ⚠ auto-install    │
+└──────────────┴────────┴────────────────┴──────────┴───────────────────┘
+```
+
+Bob approves the current state as a lockfile: `php artisan package:audit --lock`
+*(Track C — 3.1)*. In application code he uses typed config *(Track B — 3.0)*:
+
+```php
+public function index(BlogConfig $config)
+{
+    return view('blog-engine::index', ['perPage' => $config->perPage]);
+    //                                              ^ IDE-completed, boot-validated
+}
+```
+
+**Six months later**, `composer update` arrives and CI stops it *(Track C — 3.1)*:
+
+```bash
+php artisan package:audit --diff --lock
+# acme-metrics 2.3.0 → 2.4.0
+#   + global middleware Acme\Telemetry\Capture     ← NOT in approved capabilities
+# ✗ Audit failed — review before deploying (exit 1)
+```
+
+This is the supply-chain moment: a silent behavioral change in a minor release
+**cannot pass CI without human approval**.
+
+---
+
+## 3. Production and deployment
+
+Deploy script:
+
+```bash
+php artisan package:cache      # all package manifests → one file in bootstrap/cache  (Track B, 3.0)
+php artisan package:compile    # AOT fusion into a single generated provider          (Track C, 3.3)
+```
+
+```bash
+php artisan package:profile    # (Track B, 3.0)
+# ┌──────────────┬───────────────┬──────────────┐
+# │ Package      │ before        │ after cache  │
+# ├──────────────┼───────────────┼──────────────┤
+# │ blog-engine  │ 14 fs scans   │ 0 scans      │
+# │ acme-metrics │ 6 fs scans    │ 0 scans      │
+# │ boot total   │ 8.2 ms        │ 0.4 ms       │
+# └──────────────┴───────────────┴──────────────┘
+```
+
+---
+
+## 4. Documentation and AI — free by-products of the manifest *(Track C — 3.2)*
+
+```bash
+php artisan package:docs blog-engine
+# ✓ docs/packages/blog-engine.md   (routes, commands, config keys, publish tags — always current)
+# ✓ .phpstorm.meta.php             (autocomplete for config('blog-engine.*') and view('blog-engine::*'))
+# ✓ .nyon/llms.txt                 (Copilot/Claude in Bob's IDE knows what the package provides)
+```
+
+---
+
+## How it holds together
+
+```
+configure()  ──▶  Discovery  ──▶  ResourceManifest  ──▶  Registrar (runtime wiring)
+(explicit or                      (serializable
+ discover())                       data)  │
+                                          ├──▶ package:cache / compile     (performance)
+                                          ├──▶ package:audit --diff/--lock (security)
+                                          └──▶ package:docs / IDE / AI     (documentation)
+```
+
+One investment — turning the package definition into data — and all branches only read
+from it. That is why it works identically for explicit and discovered packages, and why
+it is hard to copy: a competing toolkit would have to rebuild its model first.
+
+## Walkthrough → track mapping
+
+| Walkthrough element | Track | Release |
+|---|---|---|
+| `discover()`, `hasConfig(BlogConfig::class)` | B | 3.0 |
+| `package:cache`, `package:profile` | B | 3.0 |
+| Testing kit (`assertPackagePublishes`, `assertPackageManifestCacheable`) | B | 3.0 |
+| `.nyon/manifest.json` as an open JSON standard | C | 3.1 |
+| `package:audit`, `--diff`, `--lock` (CI gate) | C | 3.1 |
+| `package:docs`, `.phpstorm.meta.php`, llms.txt | C | 3.2 |
+| `package:compile` (AOT fusion) | C | 3.3 |
+| `nyon new / dev / release` (Studio CLI) | C | separate package |
+
+Track B builds the manifest and uses it internally (performance, testing) — still "a
+better toolkit". Track C opens the manifest to the world — a public protocol and the
+tools built on it. C cannot exist without B; B is valuable even if C never ships.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,223 @@
+# Roadmap
+
+Two tracks, one rule: **nothing gets taken away.**
+
+```
+Track A — 2.x evolution      steady, non-breaking improvements; ships continuously
+Track B — 3.0 foundation     the Manifest: package definition becomes data
+Track C — 3.x platform       what only the Manifest can unlock
+```
+
+Track A keeps current users happy and de-risks the project if the platform bet takes
+longer than hoped. Tracks B and C are the upside. They share code, not fate.
+
+An end-to-end walkthrough of the platform experience (author → consumer → production)
+lives in [PLATFORM.md](PLATFORM.md).
+
+---
+
+## Guiding principle: both configuration approaches are first-class, forever
+
+The explicit fluent API and the new discovery mode are **not** competing options where
+one deprecates the other:
+
+```php
+// Approach 1 — explicit (stays first-class, never deprecated)
+$packager->name('Blog')
+    ->hasConfig()
+    ->hasRoutes(['api.php'])
+    ->hasViews();
+
+// Approach 2 — convention-based (opt-in sugar)
+$packager->name('Blog')->discover();
+
+// Mixed — discovery with explicit overrides (explicit always wins)
+$packager->name('Blog')
+    ->discover(except: ['routes'])
+    ->hasRoutes(['api.php']);
+```
+
+The design that makes this cheap to promise: **both approaches resolve into the same
+`ResourceManifest`.** Discovery is sugar; the manifest is the substance. Every platform
+feature — cache, audit, docs, compile — therefore works identically for explicitly
+configured packages and for discovered ones. Nobody is forced to migrate to conventions
+to benefit from the platform.
+
+---
+
+## Track A — 2.x evolution (parallel, non-breaking)
+
+### Quick wins (2.1.x)
+
+- PHPStan job in CI (tests and Pint already run; `composer lint` now works).
+- Guard against duplicate timeless-migration publishing (check for an existing file with
+  the same suffix before generating a new timestamp).
+- `registerConfig()`: load each config file once instead of twice.
+- `escapeshellarg()` for the GitHub-star URL passed to `exec()`.
+- Install command: report "nothing to publish" instead of a false "✅ Published" when a
+  tag has no registered paths (check `ServiceProvider::pathsToPublish()`).
+- README: document routes publish destination, `packageCommands()`, `HasAbout`
+  deprecation, fixed `hasViews()` absolute-path behavior.
+
+### Robustness (2.1.x–2.2)
+
+- `HasNamespaceResolver`: replace runtime `require vendor/autoload.php` with
+  `ClassLoader::getRegisteredLoaders()` (Composer 2 is already required).
+- PHPStan level 6+ (add iterable value types/generics), then PHPStan 2.x.
+- Additive exception hierarchy under `PackageConfigurationException` (old types stay as
+  parents/aliases until 3.0).
+
+### Parity features (ship in 2.x, carry into 3.0)
+
+- ✓ `hasEvents()` / `hasEvent()` / `hasSubscribers()` / `hasSubscriber()` — **shipped**
+- ✓ `hasOptimizeCommands()` (`optimize` / `optimize:clear`) — **shipped**
+- `hasBindings()` / `hasSingletons()`
+- `hasBladeDirectives()`
+- `hasGates()` / `hasPolicies()`
+- `hasSchedule()`
+
+### 2.2 — deprecation bridge
+
+`@deprecated` warnings for everything 3.0 removes (`HasAbout`, `bootVewComposers()`,
+redundant `InstallCommand` publish aliases, hardcoded `../` conventions), so users
+migrate on their own schedule.
+
+---
+
+## Track B — 3.0 foundation: the Manifest
+
+### Auto-discovery (opt-in)
+
+`discover()` walks the package root once and wires the conventional layout: `config/`,
+`routes/`, `lang/`, `resources/views/`, `resources/dist/`, `database/migrations/`,
+`src/Commands/`, `src/View/Components/`. Explicit `hasX()` overrides; `except:` opts out.
+
+### Resource manifest cache
+
+Today every request re-scans the filesystem during `register()`. Configuration resolves
+into a serializable **`ResourceManifest`**, cached like Laravel's own config:
+
+```bash
+php artisan package:cache      # zero directory scans afterwards
+php artisan package:profile    # per-package boot cost — the measurable, marketable win
+```
+
+### Typed config
+
+```php
+$packager->hasConfig(BlogConfig::class);   // classes accepted alongside file paths
+app(BlogConfig::class)->prefix;            // typed, IDE-completed, validated on boot
+```
+
+### Enabling refactor
+
+Split the 18-trait `Packager` god object:
+**Packager** (fluent declaration) → **Discovery** (filesystem resolve) →
+**ResourceManifest** (serializable data) → **Registrar** (container/blade/router wiring).
+Fluent API stays ~95 % source-compatible; closures (hooks, conditionals) remain the
+documented non-cacheable escape hatch.
+
+### Breaking changes (only what 2.2 already deprecated)
+
+Remove `HasAbout` + `bootVewComposers()`; unify `directory:` path convention; final
+exception hierarchy; canonical `InstallCommand` publish API; installer on laravel/prompts;
+baseline PHP 8.3+, PHPStan 2.x level 8 in CI.
+
+---
+
+## Track C — 3.x platform: what the Manifest unlocks
+
+The manifest becomes an open, versioned JSON schema — a **Package Manifest Protocol**
+("`package.json` for Laravel packages"). Works for explicit and discovered packages alike.
+
+### `package:audit` — supply-chain security (flagship)
+
+```bash
+php artisan package:audit
+# blog-engine   routes: 2   middleware: 1 alias   commands: 3   publishes: 4 tags
+# acme-metrics  ⚠ registers GLOBAL middleware     ⚠ auto-install on boot
+
+php artisan package:audit --diff
+# acme-metrics 2.3.0 → 2.4.0
+# + global middleware Acme\Telemetry\Capture   ← review before deploying
+```
+
+Manifest diffs across versions catch the classic supply-chain pattern (a minor update
+quietly adds middleware/commands) at CI time. Optional lockfile mode
+(`package:audit --lock`): approved capabilities, CI fails when exceeded — package
+permissions, like browser extensions. Category-creating; a security story travels
+further than a DX story.
+
+### `package:docs` — self-documenting packages
+
+Generate from the manifest: README sections/docs pages that cannot drift from the code,
+`.phpstorm.meta.php` + IDE completion for config keys and view namespaces, and
+machine-readable exports for AI assistants (`llms.txt`-style), so the consumer's
+Copilot/Claude knows exactly what an installed package provides.
+
+### `package:compile` — AOT fusion
+
+One step beyond per-package caching: compile all toolkit-based packages of an app into a
+single generated provider (bindings, blade components, about data inlined). Target:
+package boot cost indistinguishable from hand-written app code, proven by
+`package:profile`.
+
+### Studio — `nyon` CLI (separate package)
+
+| Command | Does |
+|---------|------|
+| `nyon new`     | interactive scaffold: skeleton, testbench, Pest, Pint, PHPStan, CI matrix |
+| `nyon dev`     | playground app (testbench serve) with file watching + live re-publish |
+| `nyon test`    | toolkit testing kit (`assertPackagePublishes`, `assertPackageManifestCacheable`, …) |
+| `nyon docs`    | docs generator with local preview |
+| `nyon release` | changelog, version bump, tag, manifest diff in the release notes |
+
+### Ecosystem (moonshot)
+
+Public index of manifest-publishing packages: auto-generated docs pages, capability
+badges ("no global middleware, no auto-install"), boot-cost score. Discovery for users,
+distribution for authors — the loop that grows protocol adoption.
+
+---
+
+## Platform experience → track mapping
+
+Which part of the [PLATFORM.md](PLATFORM.md) walkthrough each track delivers:
+
+| Walkthrough element | Track | Release |
+|---|---|---|
+| `discover()`, `hasConfig(BlogConfig::class)` | B | 3.0 |
+| `package:cache`, `package:profile` | B | 3.0 |
+| Testing kit (`assertPackagePublishes`, `assertPackageManifestCacheable`) | B | 3.0 |
+| `.nyon/manifest.json` as an open JSON standard | C | 3.1 |
+| `package:audit`, `--diff`, `--lock` (CI gate) | C | 3.1 |
+| `package:docs`, `.phpstorm.meta.php`, llms.txt | C | 3.2 |
+| `package:compile` (AOT fusion) | C | 3.3 |
+| `nyon new / dev / release` (Studio CLI) | C | separate package |
+
+Track B builds the manifest and uses it internally (performance, testing) — still "a
+better toolkit". Track C opens the manifest to the world — a public protocol and the
+tools built on it. C cannot exist without B; B is valuable even if C never ships.
+Track A is maintenance of current behavior and does not appear in the walkthrough at all.
+
+---
+
+## Combined phasing
+
+| Phase | Track | Deliverable | Release |
+|-------|-------|-------------|---------|
+| 1 | A | Quick wins + robustness | 2.1.x |
+| 2 | A | Parity features (`hasEvents`, `hasBindings`, …) | 2.2 |
+| 3 | A | Deprecation bridge | 2.2 |
+| 4 | B | Packager split → `ResourceManifest` | 3.0-alpha |
+| 5 | B | `discover()` + `package:cache` + `package:profile` | 3.0-beta |
+| 6 | B | Typed config, testing kit, prompts installer | 3.0 |
+| 7 | C | Manifest Protocol (JSON schema) + `package:audit` (+ `--diff`) | 3.1 |
+| 8 | C | `package:docs` + IDE/AI exports | 3.2 |
+| 9 | C | `package:compile` (AOT fusion) | 3.3 |
+| 10 | C | Studio CLI | separate package |
+| 11 | C | Ecosystem index | when 7–10 prove demand |
+
+Strategic rationale: Track A ships value continuously and keeps 2.x users on board;
+audit (phase 7) is the marketing spearhead right after 3.0 while attention is high;
+docs and AOT deepen the moat; Studio converts authors; the index compounds it.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 5
+    paths:
+        - src
+    tmpDir: build/phpstan
+    treatPhpDocTypesAsCertain: false

--- a/src/Concerns/HasEvents.php
+++ b/src/Concerns/HasEvents.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Concerns;
+
+use Closure;
+
+trait HasEvents
+{
+    /**
+     * @var bool Whether the package registers events.
+     */
+    private bool $isEventable = false;
+
+    /**
+     * @var array<string, array<int, string|Closure>> Map of event => listeners.
+     */
+    protected array $events = [];
+
+    /**
+     * @var array<int, string> Event subscriber classes.
+     */
+    protected array $subscribers = [];
+
+    /**
+     * Determine if the package registers any events or subscribers.
+     */
+    public function isEventable(): bool
+    {
+        return $this->isEventable;
+    }
+
+    /**
+     * Get the registered event => listeners map.
+     *
+     * @return array<string, array<int, string|Closure>>
+     */
+    public function events(): array
+    {
+        return $this->events;
+    }
+
+    /**
+     * Get the registered event subscriber classes.
+     *
+     * @return array<int, string>
+     */
+    public function subscribers(): array
+    {
+        return $this->subscribers;
+    }
+
+    /**
+     * Register multiple event listeners.
+     *
+     * Accepts a map of event class => listener(s). A listener may be a single
+     * class-string/closure or an array of them.
+     *
+     * @param  array<string, string|Closure|array<int, string|Closure>>  $events
+     */
+    public function hasEvents(array $events): static
+    {
+        foreach ($events as $event => $listeners) {
+            $this->events[$event] = array_merge(
+                $this->events[$event] ?? [],
+                is_array($listeners) ? $listeners : [$listeners]
+            );
+        }
+
+        if (! empty($this->events)) {
+            $this->isEventable = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Register a single event with one or more listeners.
+     *
+     * @param  string|Closure|array<int, string|Closure>  $listeners
+     */
+    public function hasEvent(string $event, string|Closure|array $listeners): static
+    {
+        return $this->hasEvents([$event => $listeners]);
+    }
+
+    /**
+     * Register multiple event subscriber classes.
+     *
+     * @param  array<int, string>  $subscribers
+     */
+    public function hasSubscribers(array $subscribers): static
+    {
+        if (! empty($subscribers)) {
+            $this->subscribers = array_merge(
+                $this->subscribers,
+                array_values($subscribers)
+            );
+        }
+
+        if (! empty($this->subscribers)) {
+            $this->isEventable = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Register a single event subscriber class.
+     */
+    public function hasSubscriber(string $subscriber): static
+    {
+        return $this->hasSubscribers([$subscriber]);
+    }
+}

--- a/src/Concerns/HasOptimize.php
+++ b/src/Concerns/HasOptimize.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Concerns;
+
+trait HasOptimize
+{
+    /**
+     * @var bool Whether the package registers optimize commands.
+     */
+    private bool $isOptimizable = false;
+
+    /**
+     * @var array<int, array{optimize: string|null, clear: string|null, key: string|null}>
+     */
+    protected array $optimizeCommands = [];
+
+    /**
+     * Determine if the package registers any optimize commands.
+     */
+    public function isOptimizable(): bool
+    {
+        return $this->isOptimizable;
+    }
+
+    /**
+     * Get the registered optimize command definitions.
+     *
+     * @return array<int, array{optimize: string|null, clear: string|null, key: string|null}>
+     */
+    public function optimizeCommands(): array
+    {
+        return $this->optimizeCommands;
+    }
+
+    /**
+     * Register artisan commands to run during `php artisan optimize`
+     * and `php artisan optimize:clear`.
+     *
+     * Mirrors Laravel's ServiceProvider::optimizes(). At least one of
+     * `$optimize` or `$clear` must be provided, otherwise the call is a no-op.
+     * When registering more than one entry, pass a distinct `$key` for each —
+     * entries sharing a key overwrite one another (Laravel keys by provider).
+     *
+     * @param  string|null  $optimize  Command name to run on `optimize`
+     * @param  string|null  $clear  Command name to run on `optimize:clear`
+     * @param  string|null  $key  Cache key (defaults to the package short name at boot)
+     */
+    public function hasOptimizeCommands(
+        ?string $optimize = null,
+        ?string $clear = null,
+        ?string $key = null
+    ): static {
+        if ($optimize === null && $clear === null) {
+            return $this;
+        }
+
+        $this->optimizeCommands[] = [
+            'optimize' => $optimize,
+            'clear' => $clear,
+            'key' => $key,
+        ];
+
+        $this->isOptimizable = true;
+
+        return $this;
+    }
+}

--- a/src/Concerns/HasPublishTagSeparator.php
+++ b/src/Concerns/HasPublishTagSeparator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Concerns;
+
+trait HasPublishTagSeparator
+{
+    /**
+     * @var array<int, string> Custom publish tag separators. Empty falls back to the provider default (`::`).
+     */
+    protected array $publishTagSeparators = [];
+
+    /**
+     * Set the separator(s) used when building publish tags.
+     *
+     * Publish tags are formatted as `{shortName}{separator}{group}`. The default
+     * separator is `::` (e.g. `backup-manager::config`). Pass `-` for the classic
+     * flat format (e.g. `backup-manager-config`):
+     *
+     * ```php
+     * $packager->hasPublishTagSeparator('-'); // vendor:publish --tag="backup-manager-config"
+     * ```
+     *
+     * Pass an array to register every group under **multiple** tags at once, so
+     * consumers can publish with either form:
+     *
+     * ```php
+     * $packager->hasPublishTagSeparator(['::', '-']);
+     * // both --tag="backup-manager::config" and --tag="backup-manager-config" work
+     * ```
+     *
+     * The first separator is treated as primary (used by the install command).
+     *
+     * @param  string|array<int, string>  $separator  One separator or a list of separators
+     */
+    public function hasPublishTagSeparator(string|array $separator): static
+    {
+        $separators = is_array($separator) ? $separator : [$separator];
+
+        $this->publishTagSeparators = array_values(array_unique($separators));
+
+        return $this;
+    }
+
+    /**
+     * Get the primary publish tag separator, or null when using the default.
+     */
+    public function publishTagSeparator(): ?string
+    {
+        return $this->publishTagSeparators[0] ?? null;
+    }
+
+    /**
+     * Get all configured publish tag separators (empty when using the default).
+     *
+     * @return array<int, string>
+     */
+    public function publishTagSeparators(): array
+    {
+        return $this->publishTagSeparators;
+    }
+}

--- a/src/Packager.php
+++ b/src/Packager.php
@@ -10,10 +10,13 @@ use NyonCode\LaravelPackageToolkit\Concerns\HasAssets;
 use NyonCode\LaravelPackageToolkit\Concerns\HasCommands;
 use NyonCode\LaravelPackageToolkit\Concerns\HasConditionalLoading;
 use NyonCode\LaravelPackageToolkit\Concerns\HasConfig;
+use NyonCode\LaravelPackageToolkit\Concerns\HasEvents;
 use NyonCode\LaravelPackageToolkit\Concerns\HasInstallation;
 use NyonCode\LaravelPackageToolkit\Concerns\HasMiddleware;
 use NyonCode\LaravelPackageToolkit\Concerns\HasMigrations;
+use NyonCode\LaravelPackageToolkit\Concerns\HasOptimize;
 use NyonCode\LaravelPackageToolkit\Concerns\HasProviders;
+use NyonCode\LaravelPackageToolkit\Concerns\HasPublishTagSeparator;
 use NyonCode\LaravelPackageToolkit\Concerns\HasRoutes;
 use NyonCode\LaravelPackageToolkit\Concerns\HasTranslate;
 use NyonCode\LaravelPackageToolkit\Concerns\HasViewComponentNamespaces;
@@ -31,11 +34,14 @@ class Packager
         HasCommands,
         HasConditionalLoading,
         HasConfig,
+        HasEvents,
         HasInstallation,
         HasLifecycleHooks,
         HasMiddleware,
         HasMigrations,
+        HasOptimize,
         HasProviders,
+        HasPublishTagSeparator,
         HasRoutes,
         HasTranslate,
         HasViewComponentNamespaces,

--- a/src/Support/Concerns/BootsPackageResources.php
+++ b/src/Support/Concerns/BootsPackageResources.php
@@ -4,6 +4,7 @@ namespace NyonCode\LaravelPackageToolkit\Support\Concerns;
 
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\View;
 use Seld\JsonLint\ParsingException;
 
@@ -36,6 +37,8 @@ trait BootsPackageResources
             ->bootMigrations()
             ->bootRoutes()
             ->bootMiddleware()
+            ->bootEvents()
+            ->bootOptimizes()
             ->bootSharedViewData()
             ->bootTranslations()
             ->bootViewComposers()
@@ -132,6 +135,55 @@ trait BootsPackageResources
             foreach ($this->packager->getMiddlewareGlobals() as $middleware) {
                 $kernel->pushMiddleware($middleware);
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Boot the events for the package.
+     *
+     * Registers each event => listener binding via the Event facade and
+     * subscribes any registered event subscriber classes.
+     */
+    public function bootEvents(): static
+    {
+        if (! $this->packager->isEventable()) {
+            return $this;
+        }
+
+        foreach ($this->packager->events() as $event => $listeners) {
+            foreach ($listeners as $listener) {
+                Event::listen($event, $listener);
+            }
+        }
+
+        foreach ($this->packager->subscribers() as $subscriber) {
+            Event::subscribe($subscriber);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Boot the optimize commands for the package.
+     *
+     * Registers the package's optimize/optimize:clear commands so they run
+     * with `php artisan optimize` and `php artisan optimize:clear`. Defaults
+     * the cache key to the package short name when none is provided.
+     */
+    public function bootOptimizes(): static
+    {
+        if (! $this->packager->isOptimizable()) {
+            return $this;
+        }
+
+        foreach ($this->packager->optimizeCommands() as $command) {
+            $this->optimizes(
+                optimize: $command['optimize'],
+                clear: $command['clear'],
+                key: $command['key'] ?? $this->packager->shortName()
+            );
         }
 
         return $this;

--- a/src/Support/Concerns/HasPublishingTag.php
+++ b/src/Support/Concerns/HasPublishingTag.php
@@ -5,25 +5,53 @@ namespace NyonCode\LaravelPackageToolkit\Support\Concerns;
 trait HasPublishingTag
 {
     /**
-     * @var string The separator used for tagging resources.
+     * @var string The default separator used for tagging resources.
      */
     public string $tagSeparator = '::';
 
     /**
-     *  Get the tag separator for publishing.
+     * Get the separators used for publishing tags.
+     *
+     * Separators configured on the packager (via `hasPublishTagSeparator()`)
+     * take precedence over the provider default (`::`).
+     *
+     * @return array<int, string>
      */
-    public function tagSeparator(): string
+    public function tagSeparators(): array
     {
-        return $this->tagSeparator;
+        $configured = $this->packager?->publishTagSeparators() ?? [];
+
+        return ! empty($configured) ? $configured : [$this->tagSeparator];
     }
 
     /**
-     * Format the publishing tag for a given group.
+     * Get the primary tag separator for publishing.
+     *
+     * The primary separator is the first configured one, used by the install
+     * command when building the tag it publishes.
      */
-    public function publishTagFormat(string $groupName): string
+    public function tagSeparator(): string
     {
-        return $this->packager->shortName().
-            $this->tagSeparator().
-            $groupName;
+        return $this->tagSeparators()[0];
+    }
+
+    /**
+     * Format the publishing tag(s) for a given group.
+     *
+     * Returns a single tag when one separator is configured, or an array of
+     * tags (one per separator) so the group is publishable under each form.
+     *
+     * @return string|array<int, string>
+     */
+    public function publishTagFormat(string $groupName): string|array
+    {
+        $shortName = $this->packager->shortName();
+
+        $tags = array_map(
+            fn (string $separator): string => $shortName.$separator.$groupName,
+            $this->tagSeparators()
+        );
+
+        return count($tags) === 1 ? $tags[0] : $tags;
     }
 }

--- a/stubs/provider.stub
+++ b/stubs/provider.stub
@@ -2,8 +2,8 @@
 
 //namespace {{namespace }}
 
-use NyonCode\LaravelPackageBuilder\Packager;
-use NyonCode\LaravelPackageBuilder\PackageServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\PackageServiceProvider;
 use NyonCode\LaravelPackageToolkit\Contracts\Packable;
 
 class {{ class }} extends PackageServiceProvider implements Packable

--- a/tests/PackageProviderTests/PackageAboutDataTest.php
+++ b/tests/PackageProviderTests/PackageAboutDataTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\Facades\Artisan;
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\src\TestServiceProvider;
+
+trait PackageAboutDataTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('About Test')->hasAbout()->hasVersion('9.9.9');
+
+        TestServiceProvider::$aboutDataUsing = fn (): array => [
+            'Repository' => 'https://github.com/nyoncode/laravel-package-toolkit',
+            'Author' => 'NyonCode',
+        ];
+    }
+}
+
+uses(PackageAboutDataTest::class);
+
+test('merges custom about data from the service provider with the version', function () {
+    Artisan::call('about', ['--only' => 'About Test']);
+    $output = Artisan::output();
+
+    expect($output)
+        ->toContain('Version')
+        ->toContain('9.9.9')
+        ->toContain('Repository')
+        ->toContain('https://github.com/nyoncode/laravel-package-toolkit')
+        ->toContain('Author')
+        ->toContain('NyonCode');
+});

--- a/tests/PackageProviderTests/PackageClassicInstallTagTest.php
+++ b/tests/PackageProviderTests/PackageClassicInstallTagTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\Facades\File;
+use NyonCode\LaravelPackageToolkit\Commands\InstallCommand;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+trait PackageClassicInstallTagTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Test Package')
+            ->hasPublishTagSeparator('-')
+            ->hasConfig('test-config.php')
+            ->hasInstallCommand(function (InstallCommand $command) {
+                $command->publishConfig();
+            });
+    }
+}
+
+uses(PackageClassicInstallTagTest::class);
+
+test('install command publishes using the configured tag separator', function () {
+    $this->artisan('test-package:install', ['--no-interaction' => true, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(config_path('test-config.php'))->toBeFile();
+
+    File::delete(config_path('test-config.php'));
+});

--- a/tests/PackageProviderTests/PackageClassicPublishTagTest.php
+++ b/tests/PackageProviderTests/PackageClassicPublishTagTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\ServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+trait PackageClassicPublishTagTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Test Package')
+            ->hasPublishTagSeparator('-')
+            ->hasConfig('test-config.php');
+    }
+}
+
+uses(PackageClassicPublishTagTest::class);
+
+test('registers the publish group using the classic flat tag format', function () {
+    expect(ServiceProvider::pathsToPublish(null, 'test-package-config'))
+        ->not->toBeEmpty();
+});
+
+test('publishes using the classic flat tag format', function () {
+    $this->artisan('vendor:publish --tag=test-package-config')->assertExitCode(0);
+
+    expect(config_path('test-config.php'))->toBeFile();
+});

--- a/tests/PackageProviderTests/PackageEventsClosureTest.php
+++ b/tests/PackageProviderTests/PackageEventsClosureTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Events\OrderPlaced;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Listeners\OrderSubscriber;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Listeners\RecordOrder;
+
+trait PackageEventsClosureTest
+{
+    /**
+     * Configure the packager instance
+     */
+    public function configure(Packager $packager): void
+    {
+        $packager
+            ->name('Test Package')
+            ->hasEvent(OrderPlaced::class, [
+                RecordOrder::class,
+                function (OrderPlaced $event) {
+                    RecordOrder::$handled[] = 'closure:'.$event->id;
+                },
+            ])
+            ->hasSubscribers([OrderSubscriber::class]);
+    }
+}
+
+uses(PackageEventsClosureTest::class);
+
+beforeEach(function () {
+    RecordOrder::$handled = [];
+    OrderSubscriber::$handled = [];
+});
+
+test('boot wires both class and closure listeners passed as an array', function () {
+    event(new OrderPlaced('z1'));
+
+    expect(RecordOrder::$handled)->toBe(['z1', 'closure:z1']);
+});
+
+test('boot registers subscribers passed via hasSubscribers', function () {
+    event(new OrderPlaced('z2'));
+
+    expect(OrderSubscriber::$handled)->toBe(['z2']);
+});

--- a/tests/PackageProviderTests/PackageEventsTest.php
+++ b/tests/PackageProviderTests/PackageEventsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Events\OrderPlaced;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Listeners\OrderSubscriber;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Listeners\RecordOrder;
+
+trait PackageEventsTest
+{
+    /**
+     * Configure the packager instance
+     */
+    public function configure(Packager $packager): void
+    {
+        $packager
+            ->name('Test Package')
+            ->hasEvent(OrderPlaced::class, RecordOrder::class)
+            ->hasSubscriber(OrderSubscriber::class);
+    }
+}
+
+uses(PackageEventsTest::class);
+
+beforeEach(function () {
+    RecordOrder::$handled = [];
+    OrderSubscriber::$handled = [];
+});
+
+test('registered listener handles a dispatched package event', function () {
+    event(new OrderPlaced('a1'));
+
+    expect(RecordOrder::$handled)->toBe(['a1']);
+});
+
+test('registered subscriber handles a dispatched package event', function () {
+    event(new OrderPlaced('b2'));
+
+    expect(OrderSubscriber::$handled)->toBe(['b2']);
+});

--- a/tests/PackageProviderTests/PackageMultiSeparatorPublishTest.php
+++ b/tests/PackageProviderTests/PackageMultiSeparatorPublishTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+trait PackageMultiSeparatorPublishTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Test Package')
+            ->hasPublishTagSeparator(['::', '-'])
+            ->hasConfig('test-config.php');
+    }
+}
+
+uses(PackageMultiSeparatorPublishTest::class);
+
+test('registers the publish group under both tag forms', function () {
+    expect(ServiceProvider::pathsToPublish(null, 'test-package::config'))->not->toBeEmpty()
+        ->and(ServiceProvider::pathsToPublish(null, 'test-package-config'))->not->toBeEmpty();
+});
+
+test('publishes with the :: separator tag', function () {
+    $this->artisan('vendor:publish --tag=test-package::config')->assertExitCode(0);
+
+    expect(config_path('test-config.php'))->toBeFile();
+
+    File::delete(config_path('test-config.php'));
+});
+
+test('publishes with the - separator tag', function () {
+    $this->artisan('vendor:publish --tag=test-package-config')->assertExitCode(0);
+
+    expect(config_path('test-config.php'))->toBeFile();
+
+    File::delete(config_path('test-config.php'));
+});

--- a/tests/PackageProviderTests/PackageOptimizeTest.php
+++ b/tests/PackageProviderTests/PackageOptimizeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\ServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+trait PackageOptimizeTest
+{
+    /**
+     * Configure the packager instance
+     */
+    public function configure(Packager $packager): void
+    {
+        $packager
+            ->name('Test Package')
+            ->hasOptimizeCommands(
+                optimize: 'test-package:cache',
+                clear: 'test-package:clear'
+            );
+    }
+}
+
+uses(PackageOptimizeTest::class);
+
+test('registers the optimize command under the package short name', function () {
+    expect(ServiceProvider::$optimizeCommands)
+        ->toHaveKey('test-package')
+        ->and(ServiceProvider::$optimizeCommands['test-package'])
+        ->toBe('test-package:cache');
+});
+
+test('registers the optimize:clear command under the package short name', function () {
+    expect(ServiceProvider::$optimizeClearCommands)
+        ->toHaveKey('test-package')
+        ->and(ServiceProvider::$optimizeClearCommands['test-package'])
+        ->toBe('test-package:clear');
+});

--- a/tests/PackageProviderTests/PackageOptimizeVariantsTest.php
+++ b/tests/PackageProviderTests/PackageOptimizeVariantsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\ServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+trait PackageOptimizeVariantsTest
+{
+    /**
+     * Configure the packager instance
+     */
+    public function configure(Packager $packager): void
+    {
+        $packager
+            ->name('Test Package')
+            ->hasOptimizeCommands(optimize: 'test-package:cache-a', key: 'opt-a')
+            ->hasOptimizeCommands(clear: 'test-package:clear-b', key: 'opt-b')
+            ->hasOptimizeCommands(
+                optimize: 'test-package:cache-c',
+                clear: 'test-package:clear-c',
+                key: 'opt-c'
+            );
+    }
+}
+
+uses(PackageOptimizeVariantsTest::class);
+
+test('an optimize-only entry registers no clear command', function () {
+    expect(ServiceProvider::$optimizeCommands)->toHaveKey('opt-a')
+        ->and(ServiceProvider::$optimizeCommands['opt-a'])->toBe('test-package:cache-a')
+        ->and(ServiceProvider::$optimizeClearCommands)->not->toHaveKey('opt-a');
+});
+
+test('a clear-only entry registers no optimize command', function () {
+    expect(ServiceProvider::$optimizeClearCommands)->toHaveKey('opt-b')
+        ->and(ServiceProvider::$optimizeClearCommands['opt-b'])->toBe('test-package:clear-b')
+        ->and(ServiceProvider::$optimizeCommands)->not->toHaveKey('opt-b');
+});
+
+test('multiple entries register under their distinct keys', function () {
+    expect(ServiceProvider::$optimizeCommands['opt-c'])->toBe('test-package:cache-c')
+        ->and(ServiceProvider::$optimizeClearCommands['opt-c'])->toBe('test-package:clear-c');
+});

--- a/tests/PackageProviderTests/PackageRoutesPublishTest.php
+++ b/tests/PackageProviderTests/PackageRoutesPublishTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\Facades\File;
+use NyonCode\LaravelPackageToolkit\Packager;
+
+trait PackageRoutesPublishTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Test Package')
+            ->hasRoutes();
+    }
+}
+
+uses(PackageRoutesPublishTest::class);
+
+test('can publish route files', function () {
+    $this->artisan('vendor:publish --tag=test-package::routes')->assertExitCode(0);
+
+    expect(base_path('routes/vendor/test-package/test.php'))->toBeFile()
+        ->and(base_path('routes/vendor/test-package/foo.php'))->toBeFile();
+
+    File::deleteDirectory(base_path('routes/vendor/test-package'));
+});

--- a/tests/PackageProviderTests/PackageServiceProviderTestCase.php
+++ b/tests/PackageProviderTests/PackageServiceProviderTestCase.php
@@ -81,6 +81,8 @@ abstract class PackageServiceProviderTestCase extends TestCase
         $this->resetStaticProperty(ServiceProvider::class, 'publishes', []);
         $this->resetStaticProperty(ServiceProvider::class, 'publishGroups', []);
         $this->resetStaticProperty(ServiceProvider::class, 'publishableMigrationPaths', []);
+        $this->resetStaticProperty(ServiceProvider::class, 'optimizeCommands', []);
+        $this->resetStaticProperty(ServiceProvider::class, 'optimizeClearCommands', []);
         $this->resetStaticProperty(PackageServiceProvider::class, 'isPackageAboutRegistered', false);
         AboutCommand::flushState();
     }

--- a/tests/TestPackageData/app/Events/OrderPlaced.php
+++ b/tests/TestPackageData/app/Events/OrderPlaced.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Events;
+
+class OrderPlaced
+{
+    public function __construct(public string $id = '') {}
+}

--- a/tests/TestPackageData/app/Listeners/OrderSubscriber.php
+++ b/tests/TestPackageData/app/Listeners/OrderSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Listeners;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Events\OrderPlaced;
+
+class OrderSubscriber
+{
+    /**
+     * @var array<int, string> Ids handled during the test run.
+     */
+    public static array $handled = [];
+
+    /**
+     * @return array<class-string, string>
+     */
+    public function subscribe(Dispatcher $events): array
+    {
+        return [
+            OrderPlaced::class => 'onOrderPlaced',
+        ];
+    }
+
+    public function onOrderPlaced(OrderPlaced $event): void
+    {
+        self::$handled[] = $event->id;
+    }
+}

--- a/tests/TestPackageData/app/Listeners/RecordOrder.php
+++ b/tests/TestPackageData/app/Listeners/RecordOrder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Listeners;
+
+use NyonCode\LaravelPackageToolkit\Tests\TestPackageData\app\Events\OrderPlaced;
+
+class RecordOrder
+{
+    /**
+     * @var array<int, string> Ids handled during the test run.
+     */
+    public static array $handled = [];
+
+    public function handle(OrderPlaced $event): void
+    {
+        self::$handled[] = $event->id;
+    }
+}

--- a/tests/TestPackageData/stubs/MyProvider.stub
+++ b/tests/TestPackageData/stubs/MyProvider.stub
@@ -2,8 +2,8 @@
 
 //namespace {{namespace }}
 
-use NyonCode\LaravelPackageBuilder\Packager;
-use NyonCode\LaravelPackageBuilder\PackageServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\PackageServiceProvider;
 use NyonCode\LaravelPackageToolkit\Contracts\Packable;
 
 class MyProvider extends PackageServiceProvider implements Packable

--- a/tests/TestPackageData/stubs/SecondProvider.stub
+++ b/tests/TestPackageData/stubs/SecondProvider.stub
@@ -2,8 +2,8 @@
 
 //namespace {{namespace }}
 
-use NyonCode\LaravelPackageBuilder\Packager;
-use NyonCode\LaravelPackageBuilder\PackageServiceProvider;
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\PackageServiceProvider;
 use NyonCode\LaravelPackageToolkit\Contracts\Packable;
 
 class SecondProvider extends PackageServiceProvider implements Packable

--- a/tests/Unit/HasEventsTest.php
+++ b/tests/Unit/HasEventsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\Unit;
+
+use NyonCode\LaravelPackageToolkit\Packager;
+
+beforeEach(function () {
+    $this->packager = (new Packager())->name('Test Package');
+});
+
+test('is not eventable by default', function () {
+    expect($this->packager->isEventable())->toBeFalse()
+        ->and($this->packager->events())->toBeEmpty()
+        ->and($this->packager->subscribers())->toBeEmpty();
+});
+
+test('hasEvent registers a single listener and marks the package eventable', function () {
+    $this->packager->hasEvent('order.placed', 'SendMail');
+
+    expect($this->packager->isEventable())->toBeTrue()
+        ->and($this->packager->events())->toBe(['order.placed' => ['SendMail']]);
+});
+
+test('hasEvent accepts an array of listeners', function () {
+    $this->packager->hasEvent('order.placed', ['SendMail', 'LogOrder']);
+
+    expect($this->packager->events()['order.placed'])->toBe(['SendMail', 'LogOrder']);
+});
+
+test('hasEvent accepts a closure listener', function () {
+    $listener = fn () => null;
+
+    $this->packager->hasEvent('order.placed', $listener);
+
+    expect($this->packager->events()['order.placed'])->toBe([$listener]);
+});
+
+test('hasEvent merges listeners for the same event across calls', function () {
+    $this->packager
+        ->hasEvent('order.placed', 'A')
+        ->hasEvent('order.placed', ['B', 'C']);
+
+    expect($this->packager->events()['order.placed'])->toBe(['A', 'B', 'C']);
+});
+
+test('hasEvents registers multiple events at once', function () {
+    $this->packager->hasEvents([
+        'e1' => 'L1',
+        'e2' => ['L2a', 'L2b'],
+    ]);
+
+    expect($this->packager->events())->toBe([
+        'e1' => ['L1'],
+        'e2' => ['L2a', 'L2b'],
+    ]);
+});
+
+test('hasSubscriber registers a subscriber and marks the package eventable', function () {
+    $this->packager->hasSubscriber('MySubscriber');
+
+    expect($this->packager->isEventable())->toBeTrue()
+        ->and($this->packager->subscribers())->toBe(['MySubscriber']);
+});
+
+test('hasSubscribers registers multiple subscribers', function () {
+    $this->packager->hasSubscribers(['S1', 'S2']);
+
+    expect($this->packager->subscribers())->toBe(['S1', 'S2']);
+});

--- a/tests/Unit/HasOptimizeTest.php
+++ b/tests/Unit/HasOptimizeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\Unit;
+
+use NyonCode\LaravelPackageToolkit\Packager;
+
+beforeEach(function () {
+    $this->packager = (new Packager())->name('Test Package');
+});
+
+test('is not optimizable by default', function () {
+    expect($this->packager->isOptimizable())->toBeFalse()
+        ->and($this->packager->optimizeCommands())->toBeEmpty();
+});
+
+test('registers an optimize and clear command', function () {
+    $this->packager->hasOptimizeCommands(
+        optimize: 'pkg:cache',
+        clear: 'pkg:clear'
+    );
+
+    expect($this->packager->isOptimizable())->toBeTrue()
+        ->and($this->packager->optimizeCommands())->toBe([
+            ['optimize' => 'pkg:cache', 'clear' => 'pkg:clear', 'key' => null],
+        ]);
+});
+
+test('accepts an optimize-only entry', function () {
+    $this->packager->hasOptimizeCommands(optimize: 'pkg:cache');
+
+    expect($this->packager->optimizeCommands())->toBe([
+        ['optimize' => 'pkg:cache', 'clear' => null, 'key' => null],
+    ]);
+});
+
+test('accepts a clear-only entry', function () {
+    $this->packager->hasOptimizeCommands(clear: 'pkg:clear');
+
+    expect($this->packager->optimizeCommands())->toBe([
+        ['optimize' => null, 'clear' => 'pkg:clear', 'key' => null],
+    ]);
+});
+
+test('stores a custom key', function () {
+    $this->packager->hasOptimizeCommands(optimize: 'pkg:cache', key: 'custom');
+
+    expect($this->packager->optimizeCommands()[0]['key'])->toBe('custom');
+});
+
+test('is a no-op when both optimize and clear are null', function () {
+    $this->packager->hasOptimizeCommands();
+
+    expect($this->packager->isOptimizable())->toBeFalse()
+        ->and($this->packager->optimizeCommands())->toBeEmpty();
+});
+
+test('appends multiple entries', function () {
+    $this->packager
+        ->hasOptimizeCommands(optimize: 'pkg:cache-a', key: 'a')
+        ->hasOptimizeCommands(clear: 'pkg:clear-b', key: 'b');
+
+    expect($this->packager->optimizeCommands())->toHaveCount(2);
+});

--- a/tests/Unit/HasPublishTagSeparatorTest.php
+++ b/tests/Unit/HasPublishTagSeparatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\Unit;
+
+use NyonCode\LaravelPackageToolkit\Packager;
+
+test('separator is null by default', function () {
+    expect((new Packager())->publishTagSeparator())->toBeNull();
+});
+
+test('hasPublishTagSeparator stores the separator', function () {
+    expect((new Packager())->hasPublishTagSeparator('-')->publishTagSeparator())
+        ->toBe('-');
+});
+
+test('hasPublishTagSeparator is chainable and the last call wins', function () {
+    $packager = (new Packager())
+        ->hasPublishTagSeparator('-')
+        ->hasPublishTagSeparator('.');
+
+    expect($packager->publishTagSeparator())->toBe('.');
+});
+
+test('separators is empty by default', function () {
+    expect((new Packager())->publishTagSeparators())->toBeEmpty();
+});
+
+test('hasPublishTagSeparator accepts an array of separators', function () {
+    $packager = (new Packager())->hasPublishTagSeparator(['::', '-']);
+
+    expect($packager->publishTagSeparators())->toBe(['::', '-'])
+        ->and($packager->publishTagSeparator())->toBe('::');
+});
+
+test('hasPublishTagSeparator de-duplicates separators', function () {
+    $packager = (new Packager())->hasPublishTagSeparator(['-', '-', '::']);
+
+    expect($packager->publishTagSeparators())->toBe(['-', '::']);
+});


### PR DESCRIPTION
## Summary

Adds three register-only resource types to the `Packager` fluent API, with tests and docs. Cuts the `2.2.0` release line (SemVer minor — additive, no breaking changes).

## New features

- **Events** — `hasEvents()` / `hasEvent()` / `hasSubscribers()` / `hasSubscriber()` register event listeners and subscribers, applied at boot via the `Event` facade.
- **Optimize** — `hasOptimizeCommands()` registers `optimize` / `optimize:clear` commands, forwarding to Laravel's `ServiceProvider::optimizes()`.
- **Configurable publish tag separator** — `hasPublishTagSeparator()` sets the separator used for publish tags. Pass `'-'` for the classic flat form (`my-package-config`) instead of the default `my-package::config`, or an array (`['::', '-']`) to register every group under multiple tag forms at once. Applies to `vendor:publish` tags and the install command alike.

## Tests

Unit coverage for each new trait plus integration tests for boot wiring, optimize variants, and single/multi separator publishing. Full suite: **252 passing**, PHPStan level 5 clean.

## Docs

- README, CHANGELOG (`[2.2.0]`) and ROADMAP updated.
- AI agent guidance: `AGENTS.md` + `CLAUDE.md` + `.github/copilot-instructions.md` pointing to `.ai/consuming-the-toolkit.md` and `.ai/architecture.md`.

## Tooling

- `laravel/pint` promoted to a runtime dependency.
- `composer lint` runs PHPStan with `--memory-limit=512M`.

> Note: brings the 2.1.1 fixes forward onto 2.x as well (2.2.0 branched from the 2.1.1 line).