### PR TITLE
Add self-maintaining asset mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to `laravel-package-toolkit` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.3.0] - 2026-08-07
+
+### Added
+
+- **Asset mirror** — `Support\PublishedAssets`, a container singleton shared by every package, keeps
+  `public/vendor/<package-short-name>` in step with the directory named by `hasAssets()` without anyone running a
+  command. Ask it for a URL with `app(PublishedAssets::class)->url($shortName, $absolutePath)`: the first asset of a
+  package to resolve one in a request compares each shipped file against its published counterpart and copies only
+  what is missing or older, so in steady state it is a handful of `stat` calls and no writes. Copies land through a
+  temporary file and `rename()`, so a concurrent request never sees a half-written file. The returned URL is
+  cache-busted by the published copy's mtime, which is what keeps Livewire's `data-navigate-track` meaningful across
+  an upgrade. Where `public/` cannot be written — a read-only container, Vapor — nothing throws: `url()` returns
+  `null` and `isStale()` reports a copy left behind, so the caller can fall back and warn.
+- **`hasAssets(string $directory = 'dist', bool $mirror = true)`** — the new second argument opts a package out of the
+  mirror while keeping its publish tags.
+
+### Changed
+
+- **Assets also publish under `laravel-assets`** — in addition to `<package-short-name>::assets`. That tag is what the
+  Laravel application skeleton already runs from composer's `post-update-cmd`
+  (`vendor:publish --tag=laravel-assets --ansi --force`), the same hook Horizon, Telescope and Nova rely on, so one
+  command covers every installed package. Laravel accumulates groups per path, so both tags publish the same files and
+  an untagged `vendor:publish` is unaffected.
+
 ## [2.2.0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -735,7 +735,35 @@ This loads assets from the `dist` directory by default. For a custom directory:
 $packager->hasAssets('public');
 ```
 
-Assets will be published to `public/vendor/{package-short-name}` when using the publish command.
+Assets will be published to `public/vendor/{package-short-name}` when using the publish command, under both the
+package's own `{package-short-name}::assets` tag and Laravel's conventional `laravel-assets` tag — the latter is what
+the application skeleton already runs from composer's `post-update-cmd`
+(`vendor:publish --tag=laravel-assets --ansi --force`), so one command covers every installed package.
+
+### The asset mirror
+
+Publishing is an optimisation, not a requirement. The toolkit registers a shared `PublishedAssets` resolver in the
+container that keeps `public/vendor/{package-short-name}` in step with your asset directory by itself:
+
+```php
+use NyonCode\LaravelPackageToolkit\Support\PublishedAssets;
+
+$url = app(PublishedAssets::class)->url('my-package', __DIR__.'/../dist/js/index.js');
+// => http://example.test/vendor/my-package/js/index.js?id=1730000000
+```
+
+The sync is lazy, incremental and self-correcting: the first asset of a package to resolve a URL in a request compares
+each shipped file against its published counterpart and copies only what is missing or older, so in steady state it is
+a handful of `stat` calls and no writes. Copies land through a temporary file and `rename()`, so a concurrent request
+never sees a half-written file. Where `public/` cannot be written — a read-only container, Vapor — nothing throws:
+`url()` returns `null` and you fall back to however you served the asset before. The returned URL is cache-busted by
+the published copy's mtime, which is what makes Livewire's `data-navigate-track` pick up an upgrade.
+
+To opt out and rely on `vendor:publish` alone:
+
+```php
+$packager->hasAssets(mirror: false);
+```
 
 ---
 

--- a/src/Concerns/HasAssets.php
+++ b/src/Concerns/HasAssets.php
@@ -20,6 +20,11 @@ trait HasAssets
     private string $assetDirectory = '';
 
     /**
+     * @var bool Whether the assets are mirrored into `public/vendor/<short-name>`
+     */
+    private bool $mirrorsAssets = true;
+
+    /**
      * Whether the package has assets.
      */
     public function isAssetable(): bool
@@ -33,13 +38,22 @@ trait HasAssets
     }
 
     /**
+     * Whether the package's assets are kept mirrored under `public/`.
+     */
+    public function mirrorsAssets(): bool
+    {
+        return $this->mirrorsAssets;
+    }
+
+    /**
      * Enable the package's assets.
      *
      * @param  string  $directory  The directory name where the assets are located
+     * @param  bool  $mirror  Whether to keep the assets mirrored into `public/vendor/<short-name>`
      *
      * @throws DirectoryNotFoundException if the directory does not exist
      */
-    public function hasAssets(string $directory = 'dist'): static
+    public function hasAssets(string $directory = 'dist', bool $mirror = true): static
     {
         $path = $this->path("../$directory");
 
@@ -50,6 +64,7 @@ trait HasAssets
         }
         $this->assetDirectory = $path;
         $this->isAssetable = true;
+        $this->mirrorsAssets = $mirror;
 
         return $this;
     }

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -13,6 +13,7 @@ use NyonCode\LaravelPackageToolkit\Support\Concerns\BootsPackageResources;
 use NyonCode\LaravelPackageToolkit\Support\Concerns\HasEnvironmentChecks;
 use NyonCode\LaravelPackageToolkit\Support\Concerns\HasNamespaceResolver;
 use NyonCode\LaravelPackageToolkit\Support\Concerns\HasPublishingTag;
+use NyonCode\LaravelPackageToolkit\Support\Concerns\MirrorsPackageAssets;
 use NyonCode\LaravelPackageToolkit\Support\Concerns\PublishesPackageResources;
 use NyonCode\LaravelPackageToolkit\Support\Enums\LifecycleHook;
 use ReflectionClass;
@@ -27,6 +28,7 @@ abstract class PackageServiceProvider extends ServiceProvider implements Provide
     use HasEnvironmentChecks;
     use HasNamespaceResolver;
     use HasPublishingTag;
+    use MirrorsPackageAssets;
     use PublishesPackageResources;
 
     /**
@@ -122,6 +124,7 @@ abstract class PackageServiceProvider extends ServiceProvider implements Provide
         $this->registeringPackage();
 
         $this->registerConfig();
+        $this->registerAssetMirror();
         $this->registerInstallCommand();
         $this->performAutoInstall();
 

--- a/src/Support/Concerns/MirrorsPackageAssets.php
+++ b/src/Support/Concerns/MirrorsPackageAssets.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NyonCode\LaravelPackageToolkit\Support\Concerns;
+
+use NyonCode\LaravelPackageToolkit\Support\PublishedAssets;
+
+/**
+ * The provider half of the asset mirror: it declares *where* the package ships its
+ * assets, so {@see PublishedAssets} can keep `public/vendor/{short-name}` in step
+ * with them.
+ *
+ * The split is deliberate. The provider is the only place that knows the directory
+ * for certain — it is where `hasAssets()` named it — so it hands that to the resolver
+ * rather than letting it infer one from an asset path. What it does *not* do is the
+ * copying: that stays lazy, behind the first asset of the package to resolve a URL in
+ * a request. Mirroring from `register()` or `boot()` would put a directory walk on
+ * every request the application serves, including the queue worker, the API route and
+ * the artisan command that will never emit a `<script>`.
+ *
+ * Everything is read off the packager, so the publish tags
+ * ({@see PublishesPackageResources::publishAssets()}) and the mirror cannot drift
+ * onto different directories, and `isAssetable()` means a package that never called
+ * `hasAssets()` declares nothing. `hasAssets(mirror: false)` opts a package out while
+ * keeping the publish tags.
+ */
+trait MirrorsPackageAssets
+{
+    /**
+     * Register the package's asset directory with the shared mirror.
+     */
+    protected function registerAssetMirror(): void
+    {
+        if (! ($this->packager?->isAssetable() ?? false) || ! $this->packager->mirrorsAssets()) {
+            return;
+        }
+
+        // `singletonIf`, not `singleton` — the resolver is shared by every package in
+        // the application, so the fourth provider to register must not wipe the three
+        // directories already declared.
+        $this->app->singletonIf(PublishedAssets::class);
+
+        $this->app->make(PublishedAssets::class)->mirrors(
+            $this->packager->shortName(),
+            $this->packager->assetDirectory(),
+        );
+    }
+}

--- a/src/Support/Concerns/PublishesPackageResources.php
+++ b/src/Support/Concerns/PublishesPackageResources.php
@@ -27,7 +27,16 @@ trait PublishesPackageResources
     /**
      * Publish the package assets.
      *
-     * The assets are published to the `public/vendor/<package-short-name>` directory.
+     * The assets are published to the `public/vendor/<package-short-name>` directory,
+     * under the package's own `assets` tag *and* Laravel's conventional
+     * `laravel-assets` tag.
+     *
+     * The second tag earns its place because it is what the Laravel application
+     * skeleton runs from composer's `post-update-cmd`
+     * (`vendor:publish --tag=laravel-assets --ansi --force`) — the same hook Horizon,
+     * Telescope and Nova rely on. One command covers every installed package, which
+     * the per-package tag cannot express. Laravel accumulates groups per path, so both
+     * tags publish the same files and an untagged `vendor:publish` is unaffected.
      */
     public function publishAssets(): static
     {
@@ -35,13 +44,16 @@ trait PublishesPackageResources
             return $this;
         }
 
+        $groups = (array) $this->publishTagFormat('assets');
+        $groups[] = 'laravel-assets';
+
         $this->publishes(
             paths: [
                 $this->packager->assetDirectory() => public_path(
                     path: 'vendor/'.$this->packager->shortName()
                 ),
             ],
-            groups: $this->publishTagFormat('assets')
+            groups: $groups
         );
 
         return $this;

--- a/src/Support/PublishedAssets.php
+++ b/src/Support/PublishedAssets.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NyonCode\LaravelPackageToolkit\Support;
+
+use FilesystemIterator;
+use NyonCode\LaravelPackageToolkit\Support\Concerns\MirrorsPackageAssets;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Keeps every package's asset directory mirrored into `public/vendor/{short-name}`
+ * and resolves a shipped file to that copy.
+ *
+ * Assets are served as real files under `public/`, not through a route, and the
+ * mirror maintains itself — nobody runs a command, nobody edits a vhost. That is not
+ * a convenience: route delivery only works when the request reaches PHP, and a very
+ * common nginx layout answers `.js` from a `try_files $uri =404` block that never
+ * forwards it (the same block 404s Livewire's own `/livewire/livewire.js`). On shared
+ * hosting that block is frequently not the application's to change, so a delivery
+ * mode that depends on it is not a delivery mode — it is a support ticket. A file
+ * that exists is served by every web server configuration there is.
+ *
+ * `vendor:publish --tag=laravel-assets` (or `--tag={short-name}::assets`) writes the
+ * same files to the same place; it is the same operation done ahead of time, and
+ * remains the right call for a deploy that would rather not have the first request do
+ * it. Neither one is *required*.
+ *
+ * **The sync is lazy, incremental and self-correcting.** The first asset of a package
+ * to resolve a URL in a request compares each shipped file against its published
+ * counterpart and copies only what is missing or older — in steady state that is a
+ * handful of `stat` calls and no writes at all, and after an upgrade it is one copy
+ * per changed file, on one request. Copies land through a temporary file and
+ * `rename()`, so a concurrent request never observes a half-written file.
+ *
+ * Where `public/` cannot be written — a read-only container, Vapor, a hardened
+ * deployment — nothing throws: {@see self::url()} returns `null` and the caller falls
+ * back to however it served the asset before, and if an older published copy is
+ * present it is still preferred. {@see self::isStale()} names such a copy so the
+ * caller can warn, because that combination is a production condition.
+ *
+ * The published copy is cache-busted by its own mtime, which the sync sets to the
+ * moment of the copy. That is what keeps `data-navigate-track` meaningful: Livewire
+ * full-page-reloads a `wire:navigate` visit when a tracked asset's query string
+ * changed, so an upgrade is picked up instead of running new markup against a file
+ * the browser already cached.
+ *
+ * Registered by {@see MirrorsPackageAssets}
+ * as a container singleton, so a package is examined at most once per request however
+ * many surfaces ask for its URLs.
+ */
+class PublishedAssets
+{
+    /** @var array<string, string|null> shipped path => published URL, or null when nothing is published */
+    private array $urls = [];
+
+    /** @var array<string, string> short package name => absolute asset directory, declared by its provider */
+    private array $roots = [];
+
+    /** @var array<string, true> packages already mirrored (or attempted) this request */
+    private array $synced = [];
+
+    /**
+     * Declare where a package ships its assets.
+     *
+     * Called from the provider, which is the only place that knows for certain — it
+     * is where `hasAssets()` named the directory. Reading it back beats inferring one
+     * from an asset path, and it is what keeps the mirror pointed at the same
+     * directory the publish tags copy. Registration is bookkeeping only: no directory
+     * is walked until an asset actually resolves a URL.
+     *
+     * @param  string  $package  short package name, e.g. `test-package`
+     * @param  string  $assetDirectory  absolute path of the package's asset directory
+     */
+    public function mirrors(string $package, string $assetDirectory): void
+    {
+        $this->roots[$package] = rtrim($this->normalize($assetDirectory), '/');
+    }
+
+    /**
+     * The URL of the published copy, mirroring the package first if anything is
+     * missing or out of date. `null` only when `public/` could not be written and
+     * nothing was published before.
+     *
+     * @param  string  $package  short package name, e.g. `test-package`
+     * @param  string  $path  absolute filesystem path of the shipped asset
+     */
+    public function url(string $package, string $path): ?string
+    {
+        $path = $this->normalize($path);
+
+        if (array_key_exists($path, $this->urls)) {
+            return $this->urls[$path];
+        }
+
+        $this->sync($package, $path);
+
+        $relative = $this->relativeUrl($package, $path);
+        $published = @filemtime(public_path($relative));
+
+        if ($published === false) {
+            return $this->urls[$path] = null;
+        }
+
+        return $this->urls[$path] = asset($relative).'?id='.$published;
+    }
+
+    /**
+     * Whether the published copy predates the shipped one — reachable only when the
+     * sync could not write, since otherwise it would have just replaced it.
+     *
+     * That copy is still what gets served; this only drives the warning.
+     */
+    public function isStale(string $package, string $path): bool
+    {
+        $path = $this->normalize($path);
+        $published = @filemtime(public_path($this->relativeUrl($package, $path)));
+
+        return $published !== false && $published < (@filemtime($path) ?: 0);
+    }
+
+    /**
+     * Mirror one package's asset directory into `public/vendor/{short-name}`, once
+     * per request.
+     *
+     * Every shipped file is compared, not just the ones a caller asked about: a
+     * code-split entry point imports `./chunk-<hash>.js`, which the browser fetches
+     * directly and PHP is never asked to resolve, so a mirror driven only by resolved
+     * URLs would leave that chunk behind and break the bundle.
+     */
+    private function sync(string $package, string $path): void
+    {
+        if (isset($this->synced[$package])) {
+            return;
+        }
+
+        $this->synced[$package] = true;
+
+        $root = $this->assetRoot($package, $path);
+
+        if ($root === null) {
+            return;
+        }
+
+        $target = public_path('vendor/'.$package);
+
+        foreach ($this->shippedFiles($root) as $relative => $source) {
+            $destination = $target.'/'.$relative;
+            $published = @filemtime($destination);
+
+            if ($published !== false && $published >= (@filemtime($source) ?: 0)) {
+                continue;
+            }
+
+            $this->copyAtomically($source, $destination);
+        }
+    }
+
+    /**
+     * Copy through a temporary file in the destination directory, then `rename()`.
+     *
+     * `rename()` within one filesystem is atomic, so a request that fetches the file
+     * while another is mid-copy reads either the whole old one or the whole new one —
+     * never a truncated file, which for a bundle would fail as a syntax error and take
+     * everything in it down with it.
+     */
+    private function copyAtomically(string $source, string $destination): void
+    {
+        $directory = dirname($destination);
+
+        if (! is_dir($directory) && ! @mkdir($directory, 0o755, true) && ! is_dir($directory)) {
+            return;
+        }
+
+        $temporary = $destination.'.'.bin2hex(random_bytes(8)).'.tmp';
+
+        if (! @copy($source, $temporary)) {
+            @unlink($temporary);
+
+            return;
+        }
+
+        if (! @rename($temporary, $destination)) {
+            @unlink($temporary);
+        }
+    }
+
+    /**
+     * Every file under a package's asset directory, keyed by its path relative to it
+     * — which is also its path under `public/vendor/{short-name}`, since the mirror is
+     * verbatim.
+     *
+     * @return array<string, string> relative path => absolute source path
+     */
+    private function shippedFiles(string $root): array
+    {
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $files = [];
+        $prefix = strlen(rtrim($root, '/\\')) + 1;
+
+        /** @var iterable<\SplFileInfo> $iterator */
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[str_replace('\\', '/', substr($file->getPathname(), $prefix))] = $file->getPathname();
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * One canonical, forward-slashed spelling of a path, so a root and an asset under
+     * it actually prefix-match.
+     *
+     * They otherwise need not: `hasAssets()` builds its directory by appending
+     * `../{directory}` to the package's `src/`, which leaves a literal `/../` in the
+     * string, while a caller naming an asset builds an already-resolved path. Without
+     * this, {@see self::relativeUrl()} would quietly fall back to the basename and
+     * flatten a directory the mirror copies verbatim.
+     *
+     * `realpath()` is cheap here — PHP caches it, and {@see self::url()} asks once per
+     * asset — and returns `false` for a path that does not exist, which is not an
+     * error: the string is then used as given and the caller gets the same `null` it
+     * would have anyway.
+     */
+    private function normalize(string $path): string
+    {
+        return str_replace('\\', '/', realpath($path) ?: $path);
+    }
+
+    /**
+     * The package's asset directory: what its provider declared, or — for an asset
+     * registered by an application rather than a package — the directory read back
+     * off the asset path.
+     *
+     * `null` when neither is available. Such an asset is still resolved and served by
+     * the caller; it just has no directory for the mirror to walk.
+     */
+    private function assetRoot(string $package, string $path): ?string
+    {
+        if (isset($this->roots[$package])) {
+            return $this->roots[$package];
+        }
+
+        $normalized = str_replace('\\', '/', $path);
+        $marker = strrpos($normalized, '/dist/');
+
+        return $marker === false ? null : substr($normalized, 0, $marker + 5);
+    }
+
+    /**
+     * The publish-relative URL path of one asset: `vendor/{short-name}/{path inside
+     * the asset directory}`.
+     *
+     * The path *inside* the directory is kept rather than just the basename, because
+     * the mirror copies it verbatim and entry points commonly live one level down —
+     * flattening them would break the relative chunk imports that make a code-split
+     * bundle work at all.
+     */
+    private function relativeUrl(string $package, string $path): string
+    {
+        $normalized = str_replace('\\', '/', $path);
+        $root = $this->assetRoot($package, $path);
+
+        $inside = $root !== null && str_starts_with($normalized, $root.'/')
+            ? substr($normalized, strlen($root) + 1)
+            : basename($normalized);
+
+        return 'vendor/'.$package.'/'.$inside;
+    }
+}

--- a/tests/PackageProviderTests/PackageAssetMirrorDisabledTest.php
+++ b/tests/PackageProviderTests/PackageAssetMirrorDisabledTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\Support\PublishedAssets;
+
+trait PackageAssetMirrorDisabledTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Test Package')
+            ->hasAssets(mirror: false);
+    }
+}
+
+uses(PackageAssetMirrorDisabledTest::class);
+
+test('opting out leaves the mirror unregistered', function () {
+    expect($this->app->bound(PublishedAssets::class))->toBeFalse();
+});
+
+test('opting out keeps the publish tags', function () {
+    $this->artisan('vendor:publish --tag=test-package::assets')->assertExitCode(0);
+
+    expect(public_path('vendor/test-package/css/index.css'))->toBeFile();
+});

--- a/tests/PackageProviderTests/PackageAssetMirrorTest.php
+++ b/tests/PackageProviderTests/PackageAssetMirrorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace NyonCode\LaravelPackageToolkit\Tests\PackageProviderTests;
+
+use Illuminate\Support\Facades\File;
+use NyonCode\LaravelPackageToolkit\Packager;
+use NyonCode\LaravelPackageToolkit\Support\PublishedAssets;
+
+trait PackageAssetMirrorTest
+{
+    public function configure(Packager $packager): void
+    {
+        $packager->name('Test Package')
+            ->hasAssets();
+    }
+}
+
+uses(PackageAssetMirrorTest::class);
+
+test('the mirror is registered as a shared singleton', function () {
+    expect(app()->bound(PublishedAssets::class))->toBeTrue()
+        ->and(app(PublishedAssets::class))->toBe(app(PublishedAssets::class));
+});
+
+test('resolving one asset mirrors the whole directory into public', function () {
+    $shipped = __DIR__.'/../TestPackageData/dist/css/index.css';
+
+    $url = app(PublishedAssets::class)->url('test-package', $shipped);
+
+    expect(public_path('vendor/test-package/css/index.css'))->toBeFile()
+        // Every shipped file is copied, not just the one that was resolved —
+        // a code-split chunk is fetched by the browser, never by PHP.
+        ->and(public_path('vendor/test-package/js/index.js'))->toBeFile()
+        ->and($url)->toBe(
+            asset('vendor/test-package/css/index.css')
+            .'?id='.filemtime(public_path('vendor/test-package/css/index.css'))
+        );
+});
+
+test('a published copy newer than the shipped one is left alone', function () {
+    $shipped = __DIR__.'/../TestPackageData/dist/css/index.css';
+    $published = public_path('vendor/test-package/css/index.css');
+
+    File::ensureDirectoryExists(dirname($published));
+    File::put($published, '/* published by hand */');
+    touch($published, filemtime($shipped) + 10);
+
+    app(PublishedAssets::class)->url('test-package', $shipped);
+
+    expect(File::get($published))->toBe('/* published by hand */')
+        ->and(app(PublishedAssets::class)->isStale('test-package', $shipped))->toBeFalse();
+});
+
+test('a published copy older than the shipped one is replaced', function () {
+    $shipped = __DIR__.'/../TestPackageData/dist/css/index.css';
+    $published = public_path('vendor/test-package/css/index.css');
+
+    File::ensureDirectoryExists(dirname($published));
+    File::put($published, '/* stale */');
+    touch($published, filemtime($shipped) - 10);
+
+    app(PublishedAssets::class)->url('test-package', $shipped);
+
+    expect(File::get($published))->toBe(File::get($shipped))
+        ->and(app(PublishedAssets::class)->isStale('test-package', $shipped))->toBeFalse();
+});
+
+test('assets publish under the package tag', function () {
+    $this->artisan('vendor:publish --tag=test-package::assets')->assertExitCode(0);
+
+    expect(public_path('vendor/test-package/css/index.css'))->toBeFile()
+        ->and(public_path('vendor/test-package/js/index.js'))->toBeFile();
+});
+
+test('assets publish under the conventional laravel-assets tag', function () {
+    $this->artisan('vendor:publish --tag=laravel-assets')->assertExitCode(0);
+
+    expect(public_path('vendor/test-package/css/index.css'))->toBeFile()
+        ->and(public_path('vendor/test-package/js/index.js'))->toBeFile();
+});

--- a/tests/PackageProviderTests/PackageServiceProviderTestCase.php
+++ b/tests/PackageProviderTests/PackageServiceProviderTestCase.php
@@ -43,6 +43,11 @@ abstract class PackageServiceProviderTestCase extends TestCase
 
     protected function clear(): void
     {
+        // The asset mirror writes into the workbench's `public/`, which — unlike the
+        // container — is shared by every test, so a run that published or mirrored
+        // assets would otherwise be seen by the next one.
+        File::deleteDirectory(public_path('vendor/test-package'));
+
         foreach (File::files(__DIR__.'/../TestPackageData/config') as $file) {
             $configPath = config_path($file->getFilename());
 


### PR DESCRIPTION
Assets are now served as real files under public/ without anyone running a command. Support/PublishedAssets is a container singleton shared by every package: url($shortName, $path) mirrors the package's asset directory into public/vendor/<short-name> and returns an mtime-cache-busted URL for the published copy.

Route delivery only works when the request reaches PHP, and a very common nginx layout answers .js from a `try_files $uri =404` block that never forwards it - the same block that 404s Livewire's own livewire.js. On shared hosting that block is frequently not the application's to change. A file that exists is served by every web server configuration there is.

The sync is lazy, incremental and self-correcting. The first asset of a package to resolve a URL in a request compares each shipped file against its published counterpart and copies only what is missing or older, so in steady state it is a handful of stat calls and no writes. Copies land through a temporary file and rename(), so a concurrent request never sees a half-written file. Where public/ cannot be written - a read-only container, Vapor - nothing throws: url() returns null and isStale() names a copy left behind, so the caller falls back and warns.

Every shipped file is compared, not just the ones a caller asked about: a code-split entry point imports ./chunk-<hash>.js, which the browser fetches directly and PHP is never asked to resolve.

Wiring follows the usual split: hasAssets() gains a $mirror flag (default true) on the Packager side, MirrorsPackageAssets::registerAssetMirror() acts on it from register(), right after registerConfig(). It binds with singletonIf, not singleton, so the fourth provider to register does not wipe the three directories already declared, and it only declares - mirroring from register()/boot() would put a directory walk on every request the app serves, queue workers and artisan commands included.

publishAssets() now registers the same paths under Laravel's conventional laravel-assets tag as well as <short-name>::assets. That tag is what the application skeleton runs from composer's post-update-cmd, so one command covers every installed package; publishing becomes an optimisation that moves the copy off the first request after a deploy, rather than a requirement.

PublishedAssets canonicalises every path through realpath() with a fallback, because hasAssets() stores {basePath}/../{directory} verbatim while callers name assets with resolved paths. Without it the prefix match fails and the path inside the asset directory collapses to a basename, flattening a directory the mirror copies verbatim.

Tests: integration coverage for the singleton binding, the whole-directory mirror, newer/older published copies, both publish tags and the mirror: false opt-out. The test case now clears public/vendor/test-package between runs - unlike the container, the workbench public/ is shared by every test.
